### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: Test and Build Plugin
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+
+      - name: Install deps
+        run: yarn install
+
+      # - name: Run tests
+      #   run: yarn test
+
+      - name: Run build
+        run: yarn build


### PR DESCRIPTION
Add basic github actions workflow to run build. Once we have testing standards, we can update this across and add it to .github template.