### PR TITLE
Allow http options in uploadFile (WIP)

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -96,6 +96,7 @@ public class CAPHttpPlugin: CAPPlugin {
       return call.reject("Must provide a file path to download the file to")
     }
     let name = call.getString("name") ?? "file"
+    let headers = (call.getObject("headers") ?? [:]) as [String:String]
     
     let fileDirectory = call.getString("fileDirectory") ?? "DOCUMENTS"
     
@@ -119,6 +120,7 @@ public class CAPHttpPlugin: CAPPlugin {
       return call.reject("Unable to read file to upload", "UPLOAD", e)
     }
 
+    setRequestHeaders(&request, headers)
 
     request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
     
@@ -129,10 +131,9 @@ public class CAPHttpPlugin: CAPPlugin {
         return
       }
       
-      // let res = response as! HTTPURLResponse
+      let res = response as! HTTPURLResponse
       
-      //CAPLog.print("Uploaded file", location)
-      call.resolve()
+      call.resolve(self.buildResponse(data, res))
     }
     
     task.resume()

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -123,5 +123,5 @@ export interface HttpDownloadFileResult {
   blob?: Blob;
 }
 
-export interface HttpUploadFileResult {
+export interface HttpUploadFileResult extends HttpResponse {
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -134,18 +134,16 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
   }
 
   async uploadFile(options: HttpUploadFileOptions): Promise<HttpUploadFileResult> {
-    const fetchOptions = this.makeFetchOptions(options, options.webFetchExtra);
-
     const formData = new FormData();
     formData.append(options.name, options.blob);
 
-    await fetch(options.url, {
-      ...fetchOptions,
+    const fetchOptions = {
+      ...options,
       body: formData,
-      method: 'POST'
-    });
+      method: "POST",
+    };
 
-    return {};
+    return this.request(fetchOptions);
   }
 
   async downloadFile(options: HttpDownloadFileOptions): Promise<HttpDownloadFileResult> {


### PR DESCRIPTION
This is just a proposal, I am not very familiar with Swift and have not tested the web implementation (nor added Android support). At least I can say that with those Swift changes our file upload works again.

The `downloadFile` would net similar changes and at all I think there is a lot more to do. Some things aren't implemented nor fulfilled (e.g. return missing in `setRequestDataMultipartFormData`). Maybe a roadmap would be good to track progress?