### PR TITLE
fix: reject downloadFile promise when statusCode not in 2xx range

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -48,6 +48,11 @@ public class CAPHttpPlugin: CAPPlugin {
     }
     
     let task = URLSession.shared.downloadTask(with: url) { (downloadLocation, response, error) in
+      guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+        call.reject("Invalid HTTP response code")
+        return
+      }
+
       if error != nil {
         CAPLog.print("Error on download file", downloadLocation, response, error)
         call.reject("Error", "DOWNLOAD", error, [:])

--- a/src/web.ts
+++ b/src/web.ts
@@ -152,6 +152,10 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
     const fetchOptions = this.makeFetchOptions(options, options.webFetchExtra);
 
     const ret = await fetch(options.url, fetchOptions);
+    
+    if(!ret.ok) {
+      return Promise.reject("Download file error: response not ok")
+    }
 
     const blob = await ret.blob();
 


### PR DESCRIPTION
Any statuscode that is not in the range of 2xx should reject the downloadFile method invocation.

fixes #37