### PR TITLE
Fixed additional "," character in headers

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -505,25 +505,25 @@ public class Http extends Plugin {
 
     call.resolve(ret);
   }
+  
 
   private JSArray makeResponseHeaders(HttpURLConnection conn) {
     JSArray ret = new JSArray();
 
-    for (Map.Entry<String, List<String>> entries : conn
-      .getHeaderFields()
-      .entrySet()) {
+
+    for (Map.Entry<String, List<String>> entries : conn.getHeaderFields().entrySet()) {
       JSObject header = new JSObject();
 
-      String val = "";
-      for (String headerVal : entries.getValue()) {
-        val += headerVal + ", ";
+      StringBuilder val ;
+      Iterator<String> iterator = entries.getValue().iterator();
+      val = new StringBuilder(iterator.next());
+      while (iterator.hasNext()) {
+        val.append(", ");
+        val.append(iterator.next());
       }
 
-      header.put(entries.getKey(), val);
+      header.put(entries.getKey(), val.toString());
       ret.put(header);
-    }
-
-    return ret;
   }
 
   private void setRequestHeaders(HttpURLConnection conn, JSObject headers) {


### PR DESCRIPTION
Fixed additional "," character that breaks some api calls:

There was a bug here causing an additional "," to be added to some headers. this will cause some servers to return errors (i.e when adding a , to an auth header)
