### PR TITLE
Fix for Android: UTF-8 Encoding

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -561,6 +561,13 @@ public class Http extends Plugin {
       return url;
     }
   }
+  
+  private void writeToOutputStream(OutputStream out, String data) throws IOException {
+    try(DataOutputStream os = new DataOutputStream(out)){
+      os.write(data.getBytes(StandardCharsets.UTF_8));
+      os.flush();
+    }
+  }
 
   private void setRequestBody(
     HttpURLConnection conn,
@@ -572,10 +579,7 @@ public class Http extends Plugin {
 
     if (contentType != null) {
       if (contentType.contains("application/json")) {
-        DataOutputStream os = new DataOutputStream(conn.getOutputStream());
-        os.writeBytes(data.toString());
-        os.flush();
-        os.close();
+        writeToOutputStream(conn.getOutputStream(), data.toString());
       } else if (contentType.contains("application/x-www-form-urlencoded")) {
         StringBuilder builder = new StringBuilder();
 
@@ -593,10 +597,7 @@ public class Http extends Plugin {
           }
         }
 
-        DataOutputStream os = new DataOutputStream(conn.getOutputStream());
-        os.writeBytes(builder.toString());
-        os.flush();
-        os.close();
+        writeToOutputStream(conn.getOutputStream(), builder.toString());
       } else if (contentType.contains("multipart/form-data")) {
         FormUploader uploader = new FormUploader(conn);
 


### PR DESCRIPTION
 I ran into an issue when using german umlauts (äöü) in json fields such as

`{
"name": "Jürgen"
}`

The submitted data was not properly UTF-8 encoded on android which resulted in an unparsable request on my server. Only android appears to be affected, the same request was properly encoded on iOS during my tests.