### PR TITLE
Perform android http requests in separate thread

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -47,23 +47,27 @@ public class Http extends Plugin {
 
     @PluginMethod
     public void request(PluginCall call) {
-        String url = call.getString("url");
-        String method = call.getString("method");
-        JSObject headers = call.getObject("headers");
-        JSObject params = call.getObject("params");
-
-        switch (method) {
-            case "GET":
-            case "HEAD":
-                get(call, url, method, headers, params);
-                return;
-            case "DELETE":
-            case "PATCH":
-            case "POST":
-            case "PUT":
-                mutate(call, url, method, headers);
-                return;
-        }
+        new Thread(new Runnable() {
+            public void run() {
+                String url = call.getString("url");
+                String method = call.getString("method");
+                JSObject headers = call.getObject("headers");
+                JSObject params = call.getObject("params");
+        
+                switch (method) {
+                case "GET":
+                case "HEAD":
+                    get(call, url, method, headers, params);
+                    return;
+                case "DELETE":
+                case "PATCH":
+                case "POST":
+                case "PUT":
+                    mutate(call, url, method, headers);
+                    return;
+                }
+            }
+        }).start();
     }
 
     private void get(PluginCall call, String urlString, String method, JSObject headers, JSObject params) {

--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -46,28 +46,32 @@ public class Http extends Plugin {
     }
 
     @PluginMethod
-    public void request(PluginCall call) {
-        new Thread(new Runnable() {
-            public void run() {
-                String url = call.getString("url");
-                String method = call.getString("method");
-                JSObject headers = call.getObject("headers");
-                JSObject params = call.getObject("params");
-        
-                switch (method) {
-                case "GET":
-                case "HEAD":
-                    get(call, url, method, headers, params);
-                    return;
-                case "DELETE":
-                case "PATCH":
-                case "POST":
-                case "PUT":
-                    mutate(call, url, method, headers);
-                    return;
+    public void request(final PluginCall call) {
+        new Thread(
+            new Runnable() {
+
+                public void run() {
+                    String url = call.getString("url");
+                    String method = call.getString("method");
+                    JSObject headers = call.getObject("headers");
+                    JSObject params = call.getObject("params");
+
+                    switch (method) {
+                        case "GET":
+                        case "HEAD":
+                            get(call, url, method, headers, params);
+                            return;
+                        case "DELETE":
+                        case "PATCH":
+                        case "POST":
+                        case "PUT":
+                            mutate(call, url, method, headers);
+                            return;
+                    }
                 }
             }
-        }).start();
+        )
+        .start();
     }
 
     private void get(PluginCall call, String urlString, String method, JSObject headers, JSObject params) {


### PR DESCRIPTION
I'm currently having a problem with the HTTP plugin on Android.
Whenever I try to perform an HTTP request, it seems the javascript runtime hangs and only continues when there is a result from the HTTP plugin. This is very bad for my app because we need to perform some tasks in "background" mode and still allow the user to navigate within the app. 

I've implemented a workaround for this, which is included in this PR. I am not an expert in Android development, so I am not sure whether this is the best approach (I used a simple thread).

Suggestions and other workarounds are also welcome if this PR is not appropriate. 