### PR TITLE
cator for HttpHeaders instance

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -16,7 +16,7 @@ import {
   HttpUploadFileResult,
 } from './definitions';
 import { WebPlugin, registerWebPlugin } from '@capacitor/core';
-import { HttpHeaders } from '@angular/common/http';
+import { HttpHeaders as AngularHttpHeaders } from '@angular/common/http';
 
 export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
   constructor() {
@@ -26,8 +26,8 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
     });
   }
 
-  private getRequestHeader(headers: HttpHeaders, key: string): string {
-    if (headers instanceof HttpHeaders) {
+  private getRequestHeader(headers: HttpHeaders | AngularHttpHeaders, key: string): string {
+    if (headers instanceof AngularHttpHeaders) {
       return headers.get(key);
     }
     

--- a/src/web.ts
+++ b/src/web.ts
@@ -25,7 +25,7 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
     });
   }
 
-  private getRequestHeader(headers: HttpHeaders | AngularHttpHeaders, key: string): string {
+  private getRequestHeader(headers: HttpHeaders, key: string): string {
     if (typeof headers.get === 'function') {
       return headers.get(key);
     }

--- a/src/web.ts
+++ b/src/web.ts
@@ -27,7 +27,7 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
 
   private getRequestHeader(headers: HttpHeaders, key: string): string {
     if (typeof headers.get === 'function') {
-      return headers.get(key);
+      return headers.get.apply(headers, key);
     }
     
     const originalKeys = Object.keys(headers);

--- a/src/web.ts
+++ b/src/web.ts
@@ -16,6 +16,7 @@ import {
   HttpUploadFileResult,
 } from './definitions';
 import { WebPlugin, registerWebPlugin } from '@capacitor/core';
+import { HttpHeaders } from '@angular/common/http';
 
 export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
   constructor() {
@@ -26,6 +27,10 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
   }
 
   private getRequestHeader(headers: HttpHeaders, key: string): string {
+    if (headers instanceof HttpHeaders) {
+      return headers.get(key);
+    }
+    
     const originalKeys = Object.keys(headers);
     const keys = Object.keys(headers).map(k => k.toLocaleLowerCase());
     const lowered = keys.reduce((newHeaders, key, index) => {

--- a/src/web.ts
+++ b/src/web.ts
@@ -27,7 +27,7 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
 
   private getRequestHeader(headers: HttpHeaders, key: string): string {
     if (typeof headers.get === 'function') {
-      return headers.get.apply(headers, key);
+      return (headers.get as (arg: string) => string).apply(headers, key);
     }
     
     const originalKeys = Object.keys(headers);

--- a/src/web.ts
+++ b/src/web.ts
@@ -16,7 +16,6 @@ import {
   HttpUploadFileResult,
 } from './definitions';
 import { WebPlugin, registerWebPlugin } from '@capacitor/core';
-import { HttpHeaders as AngularHttpHeaders } from '@angular/common/http';
 
 export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
   constructor() {
@@ -27,7 +26,7 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
   }
 
   private getRequestHeader(headers: HttpHeaders | AngularHttpHeaders, key: string): string {
-    if (headers instanceof AngularHttpHeaders) {
+    if (typeof headers.get === 'function') {
       return headers.get(key);
     }
     


### PR DESCRIPTION
While working with Angular HTTP interceptor, `headers` are passed in as HttpHeaders instance. The original process causes `Failed to execute 'fetch' on 'Window': Invalid value` error.  `Object.keys()` returns instance members instead of actual header keys.