### PR TITLE
Update to Capacitor v3 and some bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,10 @@
-
 .idea/
 dist
 .sourcemaps
 xcuserdata/
 node_modules/
 cli/dist/commands/copy.js
-Pods/
+Pods
 test_project/
 *.map
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -10,8 +10,6 @@ xcuserdata
 # macOS files
 .DS_Store
 
-
-
 # Based on Android gitignore template: https://github.com/github/gitignore/blob/master/Android.gitignore
 
 # Built application files

--- a/CapacitorCommunityHttp.podspec
+++ b/CapacitorCommunityHttp.podspec
@@ -1,13 +1,17 @@
+require 'json'
 
-  Pod::Spec.new do |s|
-    s.name = 'CapacitorCommunityHttp'
-    s.version = '0.0.1'
-    s.summary = 'A native HTTP plugin for CORS-free requests and file transfers'
-    s.license = 'MIT'
-    s.homepage = 'https://github.com/capacitor-community/http'
-    s.author = 'Max Lynch <max@ionic.io>'
-    s.source = { :git => 'https://github.com/capacitor-community/http', :tag => s.version.to_s }
-    s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-    s.ios.deployment_target  = '11.0'
-    s.dependency 'Capacitor'
-  end
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name = 'CapacitorCommunityHttp'
+  s.version = package['version']
+  s.summary = package['description']
+  s.license = package['license']
+  s.homepage = package['repository']['url']
+  s.author = package['author']
+  s.source = { git: package['repository']['url'], tag: s.version.to_s }
+  s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
+  s.ios.deployment_target = '12.0'
+  s.dependency 'Capacitor'
+  s.swift_version = '5.1'
+end

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 ## Maintainers
 
-| Maintainer | GitHub | Social |
-| -----------| -------| -------|
-| Max Lynch | [mlynch](https://github.com/mlynch) | [@maxlynch](https://twitter.com/maxlynch) |
+| Maintainer | GitHub                              | Social                                    |
+| ---------- | ----------------------------------- | ----------------------------------------- |
+| Max Lynch  | [mlynch](https://github.com/mlynch) | [@maxlynch](https://twitter.com/maxlynch) |
 
 ## Installation
 
@@ -38,16 +38,23 @@ On Android, register the plugin in your main activity:
 import com.getcapacitor.plugin.http.Http;
 
 public class MainActivity extends BridgeActivity {
+
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
     // Initializes the Bridge
-    this.init(savedInstanceState, new ArrayList<Class<? extends Plugin>>() {{
-      // Additional plugins you've installed go here
-      // Ex: add(TotallyAwesomePlugin.class);
-      add(Http.class);
-    }});
+    this.init(
+        savedInstanceState,
+        new ArrayList<Class<? extends Plugin>>() {
+
+          {
+            // Additional plugins you've installed go here
+            // Ex: add(TotallyAwesomePlugin.class);
+            add(Http.class);
+          }
+        }
+      );
   }
 }
 ```
@@ -190,6 +197,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/ios/Plugin/Plugin.h
+++ b/ios/Plugin/Plugin.h
@@ -7,4 +7,3 @@ FOUNDATION_EXPORT double PluginVersionNumber;
 FOUNDATION_EXPORT const unsigned char PluginVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <Plugin/PublicHeader.h>
-

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <Capacitor/Capacitor.h>
 
-CAP_PLUGIN(CAPHttpPlugin, "Http",
+CAP_PLUGIN(HttpPlugin, "Http",
   CAP_PLUGIN_METHOD(request, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(setCookie, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getCookies, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -1,94 +1,83 @@
-import Foundation
 import AudioToolbox
 import Capacitor
+import Foundation
 
-@objc(CAPHttpPlugin)
-public class CAPHttpPlugin: CAPPlugin {
+@objc(HttpPlugin) public class HttpPlugin: CAPPlugin {
 
-  @objc public func request(_ call: CAPPluginCall) {
+  @objc func request(_ call: CAPPluginCall) {
     guard let urlValue = call.getString("url") else {
       return call.reject("Must provide a URL")
     }
     guard let method = call.getString("method") else {
-      return call.reject("Must provide a method. One of GET, DELETE, HEAD PATCH, POST, or PUT")
+      return call.reject(
+        "Must provide a method. One of GET, DELETE, HEAD PATCH, POST, or PUT")
     }
-    
-    let headers = (call.getObject("headers") ?? [:]) as [String:String]
-    
-    let params = (call.getObject("params") ?? [:]) as [String:String]
-    
-    guard var url = URL(string: urlValue) else {
-      return call.reject("Invalid URL")
-    }
-    
-    
+
+    let headers = (call.getObject("headers") ?? [:]) as [String: String]
+
+    let params = (call.getObject("params") ?? [:]) as [String: String]
+
+    guard var url = URL(string: urlValue) else { return call.reject("Invalid URL") }
+
     switch method {
-    case "GET", "HEAD":
-      get(call, &url, method, headers, params)
-    case "DELETE", "PATCH", "POST", "PUT":
-      mutate(call, url, method, headers)
-    default:
-      call.reject("Unknown method")
+    case "GET", "HEAD": get(call, &url, method, headers, params)
+    case "DELETE", "PATCH", "POST", "PUT": mutate(call, url, method, headers)
+    default: call.reject("Unknown method")
     }
   }
 
-  
-  @objc public func downloadFile(_ call: CAPPluginCall) {
+  @objc func downloadFile(_ call: CAPPluginCall) {
     guard let urlValue = call.getString("url") else {
       return call.reject("Must provide a URL")
     }
     guard let filePath = call.getString("filePath") else {
       return call.reject("Must provide a file path to download the file to")
     }
-    
+
     let fileDirectory = call.getString("fileDirectory") ?? "DOCUMENTS"
-    
-    guard let url = URL(string: urlValue) else {
-      return call.reject("Invalid URL")
-    }
-    
-    let task = URLSession.shared.downloadTask(with: url) { (downloadLocation, response, error) in
+
+    guard let url = URL(string: urlValue) else { return call.reject("Invalid URL") }
+
+    let task = URLSession.shared.downloadTask(with: url) {
+      (downloadLocation, response, error) in
       if error != nil {
         CAPLog.print("Error on download file", downloadLocation, response, error)
         call.reject("Error", "DOWNLOAD", error, [:])
         return
       }
-      
+
       guard let location = downloadLocation else {
         call.reject("Unable to get file after downloading")
         return
       }
-      
+
       // TODO: Move to abstracted FS operations
       let fileManager = FileManager.default
-      
+
       let foundDir = FilesystemUtils.getDirectory(directory: fileDirectory)
       let dir = fileManager.urls(for: foundDir, in: .userDomainMask).first
-      
+
       do {
         let dest = dir!.appendingPathComponent(filePath)
         print("File Dest", dest.absoluteString)
-        
+
         try FilesystemUtils.createDirectoryForFile(dest, true)
-        
+
         try fileManager.moveItem(at: location, to: dest)
-        call.resolve([
-          "path": dest.absoluteString
-        ])
+        call.resolve(["path": dest.absoluteString])
       } catch let e {
         call.reject("Unable to download file", "DOWNLOAD", e)
         return
       }
-      
-      
+
       CAPLog.print("Downloaded file", location)
       call.resolve()
     }
-    
+
     task.resume()
   }
-  
-  @objc public func uploadFile(_ call: CAPPluginCall) {
+
+  @objc func uploadFile(_ call: CAPPluginCall) {
     guard let urlValue = call.getString("url") else {
       return call.reject("Must provide a URL")
     }
@@ -96,149 +85,121 @@ public class CAPHttpPlugin: CAPPlugin {
       return call.reject("Must provide a file path to download the file to")
     }
     let name = call.getString("name") ?? "file"
-    let headers = (call.getObject("headers") ?? [:]) as [String:String]
-    
+    let headers = (call.getObject("headers") ?? [:]) as [String: String]
+
     let fileDirectory = call.getString("fileDirectory") ?? "DOCUMENTS"
-    
-    guard let url = URL(string: urlValue) else {
-      return call.reject("Invalid URL")
-    }
-    
+
+    guard let url = URL(string: urlValue) else { return call.reject("Invalid URL") }
+
     guard let fileUrl = FilesystemUtils.getFileUrl(filePath, fileDirectory) else {
       return call.reject("Unable to get file URL")
     }
-   
+
     var request = URLRequest.init(url: url)
     request.httpMethod = "POST"
-    
+
     let boundary = UUID().uuidString
-    
+
     var fullFormData: Data?
     do {
       fullFormData = try generateFullMultipartRequestBody(fileUrl, name, boundary)
-    } catch let e {
-      return call.reject("Unable to read file to upload", "UPLOAD", e)
-    }
+    } catch let e { return call.reject("Unable to read file to upload", "UPLOAD", e) }
 
     setRequestHeaders(&request, headers)
 
-    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-    
-    let task = URLSession.shared.uploadTask(with: request, from: fullFormData) { (data, response, error) in
+    request.setValue(
+      "multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+    let task = URLSession.shared.uploadTask(with: request, from: fullFormData) {
+      (data, response, error) in
       if error != nil {
         CAPLog.print("Error on upload file", data, response, error)
         call.reject("Error", "UPLOAD", error, [:])
         return
       }
-      
+
       let res = response as! HTTPURLResponse
-      
+
       call.resolve(self.buildResponse(data, res))
     }
-    
+
     task.resume()
   }
-  
-  @objc public func setCookie(_ call: CAPPluginCall) {
-  
-    guard let key = call.getString("key") else {
-      return call.reject("Must provide key")
-    }
+
+  @objc func setCookie(_ call: CAPPluginCall) {
+    guard let key = call.getString("key") else { return call.reject("Must provide key") }
     guard let value = call.getString("value") else {
       return call.reject("Must provide value")
     }
     guard let urlString = call.getString("url") else {
       return call.reject("Must provide URL")
     }
-    
-    guard let url = URL(string: urlString) else {
-      return call.reject("Invalid URL")
-    }
-    
+
+    guard let url = URL(string: urlString) else { return call.reject("Invalid URL") }
+
     let jar = HTTPCookieStorage.shared
     let field = ["Set-Cookie": "\(key)=\(value)"]
     let cookies = HTTPCookie.cookies(withResponseHeaderFields: field, for: url)
     jar.setCookies(cookies, for: url, mainDocumentURL: url)
-    
-    call.resolve()
-  }
-  
-  @objc public func getCookies(_ call: CAPPluginCall) {
-    guard let urlString = call.getString("url") else {
-      return call.reject("Must provide URL")
-    }
-    
-    guard let url = URL(string: urlString) else {
-      return call.reject("Invalid URL")
-    }
-    
-    let jar = HTTPCookieStorage.shared
-    guard let cookies = jar.cookies(for: url) else {
-      return call.resolve([
-        "value": []
-      ])
-    }
-    
-    let c = cookies.map { (cookie: HTTPCookie) -> [String:String] in
-      return [
-        "key": cookie.name,
-        "value": cookie.value
-      ]
-    }
-    
-    call.resolve([
-      "value": c
-    ])
-  }
-  
-  @objc public func deleteCookie(_ call: CAPPluginCall) {
-    guard let urlString = call.getString("url") else {
-      return call.reject("Must provide URL")
-    }
-    guard let key = call.getString("key") else {
-      return call.reject("Must provide key")
-    }
-    guard let url = URL(string: urlString) else {
-      return call.reject("Invalid URL")
-    }
-    
-    let jar = HTTPCookieStorage.shared
-    
-    let cookie = jar.cookies(for: url)?.first(where: { (cookie) -> Bool in
-      return cookie.name == key
-    })
-    if cookie != nil {
-      jar.deleteCookie(cookie!)
-    }
-    
-    call.resolve()
-  }
-  
-  @objc public func clearCookies(_ call: CAPPluginCall) {
-    guard let urlString = call.getString("url") else {
-      return call.reject("Must provide URL")
-    }
-    guard let url = URL(string: urlString) else {
-      return call.reject("Invalid URL")
-    }
-    let jar = HTTPCookieStorage.shared
-    jar.cookies(for: url)?.forEach({ (cookie) in
-      jar.deleteCookie(cookie)
-    })
+
     call.resolve()
   }
 
-  
-  /* PRIVATE */
-  
+  @objc func getCookies(_ call: CAPPluginCall) {
+    guard let urlString = call.getString("url") else {
+      return call.reject("Must provide URL")
+    }
+
+    guard let url = URL(string: urlString) else { return call.reject("Invalid URL") }
+
+    let jar = HTTPCookieStorage.shared
+    guard let cookies = jar.cookies(for: url) else { return call.resolve(["value": []]) }
+
+    let c = cookies.map { (cookie: HTTPCookie) -> [String: String] in
+      return ["key": cookie.name, "value": cookie.value]
+    }
+
+    call.resolve(["value": c])
+  }
+
+  @objc func deleteCookie(_ call: CAPPluginCall) {
+    guard let urlString = call.getString("url") else {
+      return call.reject("Must provide URL")
+    }
+    guard let key = call.getString("key") else { return call.reject("Must provide key") }
+    guard let url = URL(string: urlString) else { return call.reject("Invalid URL") }
+
+    let jar = HTTPCookieStorage.shared
+
+    let cookie = jar.cookies(for: url)?.first(where: { (cookie) -> Bool in
+      return cookie.name == key
+    })
+    if cookie != nil { jar.deleteCookie(cookie!) }
+
+    call.resolve()
+  }
+
+  @objc func clearCookies(_ call: CAPPluginCall) {
+    guard let urlString = call.getString("url") else {
+      return call.reject("Must provide URL")
+    }
+    guard let url = URL(string: urlString) else { return call.reject("Invalid URL") }
+    let jar = HTTPCookieStorage.shared
+    jar.cookies(for: url)?.forEach({ (cookie) in jar.deleteCookie(cookie) })
+    call.resolve()
+  }
+
   // Handle GET operations
-  func get(_ call: CAPPluginCall, _ url: inout URL, _ method: String, _ headers: [String:String], _ params: [String:String]) {
+  func get(
+    _ call: CAPPluginCall, _ url: inout URL, _ method: String,
+    _ headers: [String: String], _ params: [String: String]
+  ) {
     setUrlQuery(&url, params)
-    
+
     var request = URLRequest(url: url)
-    
+
     request.httpMethod = method
-    
+
     setRequestHeaders(&request, headers)
 
     let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
@@ -246,50 +207,48 @@ public class CAPHttpPlugin: CAPPlugin {
         call.reject("Error", "GET", error, [:])
         return
       }
-      
+
       let res = response as! HTTPURLResponse
-     
+
       call.resolve(self.buildResponse(data, res))
     }
-    
+
     task.resume()
   }
-  
-  func setUrlQuery(_ url: inout URL, _ params: [String:String]) {
+
+  func setUrlQuery(_ url: inout URL, _ params: [String: String]) {
     var cmps = URLComponents(url: url, resolvingAgainstBaseURL: true)
-    if cmps?.queryItems == nil {
-      cmps?.queryItems = []
-    }
-    cmps!.queryItems?.append(contentsOf: params.map({ (key, value) -> URLQueryItem in
-      return URLQueryItem(name: key, value: value)
-    }))
+    if cmps?.queryItems == nil { cmps?.queryItems = [] }
+    cmps!.queryItems?.append(
+      contentsOf: params.map({ (key, value) -> URLQueryItem in
+        return URLQueryItem(name: key, value: value)
+      }))
     url = cmps!.url!
   }
-  
-  func setRequestHeaders(_ request: inout URLRequest, _ headers: [String:String]) {
-    headers.keys.forEach { (key) in
-      guard let value = headers[key] else {
-        return
-      }
+
+  func setRequestHeaders(_ request: inout URLRequest, _ headers: [String: String]) {
+    headers.keys.forEach { (key) in guard let value = headers[key] else { return }
       request.addValue(value, forHTTPHeaderField: key)
     }
   }
-  
+
   // Handle mutation operations: DELETE, PATCH, POST, and PUT
-  func mutate(_ call: CAPPluginCall, _ url: URL, _ method: String, _ headers: [String:String]) {
+  func mutate(
+    _ call: CAPPluginCall, _ url: URL, _ method: String, _ headers: [String: String]
+  ) {
     let data = call.getObject("data")
-    
+
     var request = URLRequest(url: url)
     request.httpMethod = method
-  
+
     setRequestHeaders(&request, headers)
-    
+
     let contentType = getRequestHeader(headers, "Content-Type") as? String
-    
+
     if data != nil && contentType != nil {
-      do {
-        request.httpBody = try getRequestData(request, data!, contentType!)
-      } catch let e {
+      do { request.httpBody = try getRequestData(request, data!, contentType!) } catch let
+        e
+      {
         call.reject("Unable to set request data", "MUTATE", e)
         return
       }
@@ -300,48 +259,49 @@ public class CAPHttpPlugin: CAPPlugin {
         call.reject("Error", "MUTATE", error, [:])
         return
       }
-      
+
       let res = response as! HTTPURLResponse
-     
+
       call.resolve(self.buildResponse(data, res))
     }
-    
+
     task.resume()
   }
 
-  func buildResponse(_ data: Data?, _ response: HTTPURLResponse) -> [String:Any] {
-    
-    var ret = [:] as [String:Any]
-    
+  func buildResponse(_ data: Data?, _ response: HTTPURLResponse) -> [String: Any] {
+    var ret = [:] as [String: Any]
+
     ret["status"] = response.statusCode
     ret["headers"] = response.allHeaderFields
-    
+
     let contentType = response.allHeaderFields["Content-Type"] as? String
 
     if data != nil && contentType != nil && contentType!.contains("application/json") {
-      if let json = try? JSONSerialization.jsonObject(with: data!, options: .mutableContainers) {
+      if let json = try? JSONSerialization.jsonObject(
+        with: data!, options: .mutableContainers)
+      {
         ret["data"] = json
       }
     } else {
-      if (data != nil) {
-        ret["data"] = String(data: data!, encoding: .utf8);
+      if data != nil {
+        ret["data"] = String(data: data!, encoding: .utf8)
       } else {
         ret["data"] = ""
       }
     }
-    
+
     return ret
   }
-  
-  func getRequestHeader(_ headers: [String:Any], _ header: String) -> Any? {
-    var normalizedHeaders = [:] as [String:Any]
-    headers.keys.forEach { (key) in
-      normalizedHeaders[key.lowercased()] = headers[key]
-    }
+
+  func getRequestHeader(_ headers: [String: Any], _ header: String) -> Any? {
+    var normalizedHeaders = [:] as [String: Any]
+    headers.keys.forEach { (key) in normalizedHeaders[key.lowercased()] = headers[key] }
     return normalizedHeaders[header.lowercased()]
   }
-  
-  func getRequestData(_ request: URLRequest, _ data: [String:Any], _ contentType: String) throws -> Data? {
+
+  func getRequestData(_ request: URLRequest, _ data: [String: Any], _ contentType: String)
+    throws -> Data?
+  {
     if contentType.contains("application/json") {
       return try setRequestDataJson(request, data)
     } else if contentType.contains("application/x-www-form-urlencoded") {
@@ -351,47 +311,49 @@ public class CAPHttpPlugin: CAPPlugin {
     }
     return nil
   }
-  
-  func setRequestDataJson(_ request: URLRequest, _ data: [String:Any]) throws -> Data? {
+
+  func setRequestDataJson(_ request: URLRequest, _ data: [String: Any]) throws -> Data? {
     let jsonData = try JSONSerialization.data(withJSONObject: data)
     return jsonData
   }
-  
-  func setRequestDataFormUrlEncoded(_ request: URLRequest, _ data: [String:Any]) -> Data? {
-    guard var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false) else {
-      return nil
-    }
+
+  func setRequestDataFormUrlEncoded(_ request: URLRequest, _ data: [String: Any]) -> Data?
+  {
+    guard
+      var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+    else { return nil }
     components.queryItems = []
     data.keys.forEach { (key) in
       components.queryItems?.append(URLQueryItem(name: key, value: "\(data[key] ?? "")"))
     }
-    
-    if components.query != nil {
-      return Data(components.query!.utf8)
-    }
-    
+
+    if components.query != nil { return Data(components.query!.utf8) }
+
     return nil
   }
-  
-  func setRequestDataMultipartFormData(_ request: URLRequest, _ data: [String:Any]) -> Data? {
-    return nil
-  }
-  
-  
-  func generateFullMultipartRequestBody(_ url: URL, _ name: String, _ boundary: String) throws -> Data {
+
+  func setRequestDataMultipartFormData(_ request: URLRequest, _ data: [String: Any])
+    -> Data?
+  { return nil }
+
+  func generateFullMultipartRequestBody(_ url: URL, _ name: String, _ boundary: String)
+    throws -> Data
+  {
     var data = Data()
-    
+
     let fileData = try Data(contentsOf: url)
 
-    
     let fname = url.lastPathComponent
     let mimeType = FilesystemUtils.mimeTypeForPath(path: fname)
     data.append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
-    data.append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(fname)\"\r\n".data(using: .utf8)!)
+    data.append(
+      "Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(fname)\"\r\n".data(
+        using: .utf8)!)
     data.append("Content-Type: \(mimeType)\r\n\r\n".data(using: .utf8)!)
     data.append(fileData)
     data.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
-    
+
     return data
   }
+
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -96,6 +96,7 @@ public class CAPHttpPlugin: CAPPlugin {
       return call.reject("Must provide a file path to download the file to")
     }
     let name = call.getString("name") ?? "file"
+    let headers = (call.getObject("headers") ?? [:]) as [String:String]
     
     let fileDirectory = call.getString("fileDirectory") ?? "DOCUMENTS"
     
@@ -119,6 +120,7 @@ public class CAPHttpPlugin: CAPPlugin {
       return call.reject("Unable to read file to upload", "UPLOAD", e)
     }
 
+    setRequestHeaders(&request, headers)
 
     request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
     
@@ -129,10 +131,9 @@ public class CAPHttpPlugin: CAPPlugin {
         return
       }
       
-      // let res = response as! HTTPURLResponse
+      let res = response as! HTTPURLResponse
       
-      //CAPLog.print("Uploaded file", location)
-      call.resolve()
+      call.resolve(self.buildResponse(data, res))
     }
     
     task.resume()

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,10 +1,10 @@
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 def capacitor_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
-  pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
-  pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
+  pod 'Capacitor', path: '../node_modules/@capacitor/ios'
+  pod 'CapacitorCordova', path: '../node_modules/@capacitor/ios'
 end
 
 target 'Plugin' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Capacitor (2.0.2):
-    - CapacitorCordova (= 2.0.2)
-  - CapacitorCordova (2.0.2)
+  - Capacitor (3.0.0-alpha.11):
+    - CapacitorCordova
+  - CapacitorCordova (3.0.0-alpha.11)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
@@ -14,9 +14,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  Capacitor: 8197af225080b4135ad39d76ae44cd0b8dc87519
-  CapacitorCordova: e45e617a0b5fe6a27f7b822b2014f9c12e8a8198
+  Capacitor: 4c6d011175f6ca4a940288cf8dc3157fa58c794e
+  CapacitorCordova: 2a326748902004232e7524d2b123a924a4049b20
 
-PODFILE CHECKSUM: 18edf3816e869cc37578950affc00fdd78ee0dcb
+PODFILE CHECKSUM: b7b76f9a39066f9f3276fd95a6e5ca9625f20b3f
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,24 +98,34 @@
       }
     },
     "@capacitor/android": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-2.4.0.tgz",
-      "integrity": "sha512-5sJicZjtuBRgtmBuV1kvWnIjlu7bnw2TGGp62UXf0ZrjvMUCYSFHBqIHZ8neffW7a3xM5cdGMUlxJ+HfA9ntAg==",
-      "dev": true
+      "version": "3.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-3.0.0-alpha.11.tgz",
+      "integrity": "sha512-FGJZE3+Kh8j8uIQVLoJcsjL0L70oFdhdafFXvBnTVwWK6hFJrBtqrpVk6rxHg6cLscGiTAcvueWsh6dmfvLp5Q=="
     },
     "@capacitor/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-zL+3yKjLNkU6QwIB/Fp9rg+qDLsO44/ibrIgaZZRXcDCwScwanjXCgco/jXQl3jGFcZzanm59wKhMcJr9xQH0Q==",
+      "version": "3.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.0.0-alpha.9.tgz",
+      "integrity": "sha512-OdaLJ9Tvx6hDkhBqqFxQaXSLnfWWnfk/dsl/oDVs/0IJ7Exh4IPgs+kdv9XNjtGdEG6sq4E6C7JeUEQp0rxrSg==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
       }
     },
+    "@capacitor/filesystem": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/filesystem/-/filesystem-0.1.1.tgz",
+      "integrity": "sha512-63tCDRXzf/9k26ueOjtLzJIEJRIwVLgfMrWCkntsKHmywnWxpMuw7yuLx4gsBxTkzzYkP5MC4xXb2xmGp8FS6Q=="
+    },
     "@capacitor/ios": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-2.4.0.tgz",
-      "integrity": "sha512-G4WcQHS4RuK94Ncoi5K+r12DWPqkB8yZKupQrJaGT1S/Zyc3mcA9m1f4HwRPlYCwyxQ6lCd8+N9GYxLu7Kv+SA==",
-      "dev": true
+      "version": "3.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-3.0.0-alpha.11.tgz",
+      "integrity": "sha512-+mzh5j+fia+g/T64D5poGj84hoctBhbXOPb5QFYb/nChD6bM6aoC3tzkRSHNzgxQ8TYq/CuGNMW+wk/UPOMKbw=="
     },
     "@ionic/prettier-config": {
       "version": "1.0.0",
@@ -1112,6 +1122,13 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
     },
     "get-stream": {
       "version": "5.1.0",
@@ -3214,6 +3231,15 @@
         "glob": "^7.1.3"
       }
     },
+    "rollup": {
+      "version": "2.35.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.35.1.tgz",
+      "integrity": "sha512-q5KxEyWpprAIcainhVy6HfRttD9kutQpHbeqDTWnqAFNJotiojetK6uqmcydNMymBEtC4I8bCYR+J3mTMqeaUA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      }
+    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -3545,7 +3571,8 @@
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "scripts": {
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc && rollup -c rollup.config.js",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
     "fmt": "npm run prettier -- --write",
@@ -16,11 +16,12 @@
   "author": "Max Lynch <max@ionic.io>",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/android": "^3.0.0-alpha.11",
+    "@capacitor/core": "^3.0.0-alpha.9",
+    "@capacitor/filesystem": "^0.1.1",
+    "@capacitor/ios": "^3.0.0-alpha.11"
   },
   "devDependencies": {
-    "@capacitor/android": "latest",
-    "@capacitor/ios": "latest",
     "@ionic/prettier-config": "^1.0.0",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
@@ -34,6 +35,7 @@
     "prettier-plugin-java": "^0.8.0",
     "pretty-quick": "^2.0.1",
     "rimraf": "^3.0.0",
+    "rollup": "^2.35.1",
     "typescript": "^3.2.4"
   },
   "husky": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,14 @@
-import nodeResolve from 'rollup-plugin-node-resolve';
-
 export default {
   input: 'dist/esm/index.js',
   output: {
     file: 'dist/plugin.js',
     format: 'iife',
-    name: 'capacitorPlugin',
+    name: 'capacitorCommunityHttp',
+    globals: {
+      '@capacitor/core': 'capacitorExports',
+    },
     sourcemap: true,
+    inlineDynamicImports: true,
   },
-  plugins: [nodeResolve()],
+  external: ['@capacitor/core'],
 };

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -125,4 +125,4 @@ export interface HttpDownloadFileResult {
   blob?: Blob;
 }
 
-export interface HttpUploadFileResult {}
+export interface HttpUploadFileResult extends HttpResponse {}

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,10 +1,4 @@
-declare module '@capacitor/core' {
-  interface PluginRegistry {
-    Http: HttpPlugin;
-  }
-}
-
-import { FilesystemDirectory } from '@capacitor/core';
+import { Directory } from '@capacitor/filesystem';
 
 export interface HttpPlugin {
   request(options: HttpOptions): Promise<HttpResponse>;
@@ -63,7 +57,7 @@ export interface HttpDownloadFileOptions extends HttpOptions {
    *
    * If this option is used, filePath can be a relative path rather than absolute
    */
-  fileDirectory?: FilesystemDirectory;
+  fileDirectory?: Directory;
 }
 
 export interface HttpUploadFileOptions extends HttpOptions {
@@ -88,7 +82,7 @@ export interface HttpUploadFileOptions extends HttpOptions {
    *
    * If this option is used, filePath can be a relative path rather than absolute
    */
-  fileDirectory?: FilesystemDirectory;
+  fileDirectory?: Directory;
 }
 
 export interface HttpCookie {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,11 @@
+import { registerPlugin } from '@capacitor/core';
+
+import type { HttpPlugin } from './definitions';
+
+const Http = registerPlugin<HttpPlugin>('Http', {
+  web: () => import('./web').then(m => new m.HttpWeb()),
+  electron: () => import('./web').then(m => new m.HttpWeb()),
+});
+
 export * from './definitions';
-export * from './web';
+export { Http };

--- a/src/web.ts
+++ b/src/web.ts
@@ -162,18 +162,16 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
   async uploadFile(
     options: HttpUploadFileOptions,
   ): Promise<HttpUploadFileResult> {
-    const fetchOptions = this.makeFetchOptions(options, options.webFetchExtra);
-
     const formData = new FormData();
     formData.append(options.name, options.blob);
 
-    await fetch(options.url, {
-      ...fetchOptions,
+    const fetchOptions = {
+      ...options,
       body: formData,
       method: 'POST',
-    });
+    };
 
-    return {};
+    return this.request(fetchOptions);
   }
 
   async downloadFile(

--- a/src/web.ts
+++ b/src/web.ts
@@ -15,14 +15,11 @@ import {
   HttpUploadFileOptions,
   HttpUploadFileResult,
 } from './definitions';
-import { WebPlugin, registerWebPlugin } from '@capacitor/core';
+import { WebPlugin } from '@capacitor/core';
 
-export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
+export class HttpWeb extends WebPlugin implements HttpPlugin {
   constructor() {
-    super({
-      name: 'Http',
-      platforms: ['web', 'electron'],
-    });
+    super();
   }
 
   private getRequestHeader(headers: HttpHeaders, key: string): string {
@@ -48,12 +45,12 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
 
   private makeFetchOptions(
     options: HttpOptions,
-    fetchExtra: RequestInit,
+    fetchExtra: RequestInit = {},
   ): RequestInit {
     const req = {
       method: options.method || 'GET',
       headers: options.headers,
-      ...(fetchExtra || {}),
+      ...fetchExtra,
     } as RequestInit;
 
     const contentType =
@@ -74,7 +71,7 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
     return req;
   }
 
-  private makeFetchParams(params: HttpParams): string | null {
+  private makeFetchParams(params?: HttpParams): string | null {
     if (!params) return null;
     return Object.entries(params).reduce((prev, [key, value]) => {
       const encodedValue = encodeURIComponent(value);
@@ -163,7 +160,7 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
     options: HttpUploadFileOptions,
   ): Promise<HttpUploadFileResult> {
     const formData = new FormData();
-    formData.append(options.name, options.blob);
+    formData.append(options.name, options.blob || 'undefined');
 
     const fetchOptions = {
       ...options,
@@ -189,8 +186,6 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
   }
 }
 
-const Http = new HttpPluginWeb();
+const Http = new HttpWeb();
 
 export { Http };
-
-registerWebPlugin(Http);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,19 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": false,
     "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "dom",
-      "es2015"
-    ],
-    "module": "es2015",
+    "esModuleInterop": true,
+    "lib": ["dom"],
+    "module": "esnext",
     "moduleResolution": "node",
-    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "dist/esm",
+    "pretty": true,
     "sourceMap": true,
-    "target": "es2015"
+    "strict": true,
+    "target": "es2017"
   },
-  "files": [
-    "src/index.ts"
-  ]
+  "files": ["src/index.ts"]
 }


### PR DESCRIPTION
Decided to create this merge request for any further development. We use our own version in our project because it takes too long for updates to get pushed to npm.

Whats included:

- In the Swift version of `upload` headers weren't included
- Missing type definitions for `uploadFile`
- Simplify `uploadFile`
- Make iOS and Web Version Capacitor 3 ready (Android NOT included, because I don't have any experience with it and we haven't yet deployed to Google Play)

Feel free to use it as a reference or merge it into the cap-3 branch.

Just mention you here because I have seen you already took some effort into making it v3 ready @thomasvidas.