### PR TITLE
Fix (Android) add line break in GET request data

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -391,7 +391,7 @@ public class Http extends Plugin {
         StringBuilder builder = new StringBuilder();
         String line;
         while ((line = in.readLine()) != null) {
-            builder.append(line);
+            builder.append(line).append(System.getProperty("line.separator"));
         }
         in.close();
 


### PR DESCRIPTION
When the request data is being obtained. They are added line by line and the line break is being omitted. Causing errors when parsing the data.
This error only occurs on Android