### PR TITLE
Add 'expires' option to Http.setCookie

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -102,6 +102,7 @@ export interface HttpSetCookieOptions {
   key: string;
   value: string;
   ageDays?: number;
+  expires?: string;
 }
 
 export interface HttpGetCookiesOptions {

--- a/src/web.ts
+++ b/src/web.ts
@@ -112,7 +112,10 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
 
   async setCookie(options: HttpSetCookieOptions) {
     var expires = '';
-    if (options.ageDays) {
+    if (options.expires) {
+      // remove "expires=" so you can pass with or without the prefix
+      expires = `; expires=${expires.replace('expires=', '')}`;
+    } else if (options.ageDays) {
       const date = new Date();
       date.setTime(date.getTime() + options.ageDays * 24 * 60 * 60 * 1000);
       expires = '; expires=' + date.toUTCString();


### PR DESCRIPTION
Adds optional `expires` to `HttpSetCookieOptions` type. If both the `expires` and `agesDays` options are set, the function will use `expires`.

Fixes #16 