### PR TITLE
Fix for empty query params adding ? on ios

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -262,14 +262,16 @@ public class CAPHttpPlugin: CAPPlugin {
   }
   
   func setUrlQuery(_ url: inout URL, _ params: [String:String]) {
-    var cmps = URLComponents(url: url, resolvingAgainstBaseURL: true)
-    if cmps?.queryItems == nil {
-      cmps?.queryItems = []
+    if (params.count != 0) {
+        var cmps = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        if cmps?.queryItems == nil {
+          cmps?.queryItems = []
+        }
+        cmps!.queryItems?.append(contentsOf: params.map({ (key, value) -> URLQueryItem in
+          return URLQueryItem(name: key, value: value)
+        }))
+        url = cmps!.url!
     }
-    cmps!.queryItems?.append(contentsOf: params.map({ (key, value) -> URLQueryItem in
-      return URLQueryItem(name: key, value: value)
-    }))
-    url = cmps!.url!
   }
   
   func setRequestHeaders(_ request: inout URLRequest, _ headers: [String:String]) {


### PR DESCRIPTION
Only modify the URL if the params map has values in it

Fixes #64 