### PR TITLE
Fix for #15 Encode response according to `responseType`

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -396,13 +396,7 @@ public class Http extends Plugin {
         InputStream errorStream = conn.getErrorStream();
         InputStream stream = (errorStream != null ? errorStream : conn.getInputStream());
 
-        BufferedReader in = new BufferedReader(new InputStreamReader(stream));
-        StringBuilder builder = new StringBuilder();
-        String line;
-        while ((line = in.readLine()) != null) {
-            builder.append(line).append(System.getProperty("line.separator"));
-        }
-        in.close();
+        String responseString = readAsString(stream);
 
         Log.d(getLogTag(), "GET request completed, got data");
 
@@ -411,17 +405,17 @@ public class Http extends Plugin {
         if (contentType != null) {
             if (contentType.contains("application/json")) {
                 try {
-                    JSObject jsonValue = new JSObject(builder.toString());
+                    JSObject jsonValue = new JSObject(responseString);
                     ret.put("data", jsonValue);
                 } catch (JSONException e) {
-                    JSArray jsonValue = new JSArray(builder.toString());
+                    JSArray jsonValue = new JSArray(responseString);
                     ret.put("data", jsonValue);
                 }
             } else {
-                ret.put("data", builder.toString());
+                ret.put("data", responseString);
             }
         } else {
-            ret.put("data", builder.toString());
+            ret.put("data", responseString);
         }
 
         call.resolve(ret);
@@ -443,6 +437,17 @@ public class Http extends Plugin {
         }
 
         return ret;
+    }
+
+    private String readAsString(InputStream in) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+            StringBuilder builder = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                builder.append(line).append(System.getProperty("line.separator"));
+            }
+            return builder.toString();
+        }
     }
 
     private void setRequestHeaders(HttpURLConnection conn, JSObject headers) {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -327,10 +327,10 @@ public class CAPHttpPlugin: CAPPlugin {
     
     let contentType = response.allHeaderFields["Content-Type"] as? String
 
-    if data != nil && contentType != nil && contentType!.contains("application/json") {
-      if let json = try? JSONSerialization.jsonObject(with: data!, options: .mutableContainers) {
-        ret["data"] = json
-      }
+    if let data = data, let contentType = contentType, contentType.contains("application/json") {
+        if let json = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) {
+            ret["data"] = json
+        }
     } else {
       if (data != nil) {
         ret["data"] = String(data: data!, encoding: .utf8);

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -37,6 +37,11 @@ export interface HttpOptions {
    * Extra arguments for fetch when running on the web
    */
   webFetchExtra?: RequestInit;
+  /**
+   * This is used to parse the response appropriately before returning it to
+   * the requestee.
+   */
+  responseType?: 'arraybuffer' | 'blob' | 'json' | 'text' | 'document';
 }
 
 export interface HttpParams {


### PR DESCRIPTION
Instead of just treating all responses as strings, consider `responseType` to properly encoding the data received from the server.

This should fix https://github.com/capacitor-community/http/issues/15