### PR TITLE
bugfix android json null value

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -216,7 +216,7 @@ public class HttpRequestHandler {
      */
     private static Object parseJSON(String input) throws JSONException {
         try {
-            if ("null".equals(input)) {
+            if ("null".equals(input.trim())) {
                 return JSONObject.NULL;
             } else {
                 try {


### PR DESCRIPTION
My previous fix for json null value (#90) doesn't work with capacitor-v3 anymore.
Because, com.getcapacitor.plugin.http.HttpRequestHandler#readStreamAsString add a new line on String.
I added .trim() on the json null value check and it works correctly again.