### PR TITLE
Web implementation: FormData typed request body

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -75,8 +75,14 @@ export const buildRequestInit = (
     typeof options.data === 'object'
   ) {
     const form = new FormData();
-    for (const [key, value] of Object.entries(options.data || {})) {
-      form.append(key, value as any);
+    if (options.data instanceof FormData) {
+      options.data.forEach((value, key) => {
+        form.append(key, value);
+      });
+    } else {
+      for (let key of Object.keys(options.data)) {
+        form.append(key, options.data[key]);
+      }
     }
     output.body = form;
   }


### PR DESCRIPTION
The current web implementation seems to not include anything in the request body if the _data_ property is a _FormData_ object. In my opinion, the problem lays in iterating over the _FormData_ content using _Object.keys()_, which doesn't seem to return anything for a _FormData_ object. My suggestion is to use a separate _FormData_ specific method to iterate over the _FormData_ content.