### PR TITLE
Use the default response type if the response is not ok

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -100,7 +100,7 @@ export const request = async (options: HttpOptions): Promise<HttpResponse> => {
   const contentType = response.headers.get('content-type') || '';
 
   // Default to 'text' responseType so no parsing happens
-  let { responseType = 'text' } = options;
+  let { responseType = 'text' } = response.ok ? options : {};
 
   // If the response content-type is json, force the response to be json
   if (contentType.includes('application/json')) {


### PR DESCRIPTION
-Since the response type was meant for the ok response, use either 'text' or 'json' (if the 'content-type' header matches) to avoid parsing errors of an error response that might not conform to the specified response type in the HttpOptions.
-This behavior is consistent with the Android implementation of the plugin