### PR TITLE
Add option to set cookie expiration in android/ios

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -305,6 +305,8 @@ public class Http extends Plugin {
         String url = call.getString("url");
         String key = call.getString("key");
         String value = call.getString("value");
+        String expires = call.getString("expires");
+        Integer ageDays = call.getInt("ageDays");
 
         URI uri = getUri(url);
         if (uri == null) {
@@ -312,7 +314,15 @@ public class Http extends Plugin {
             return;
         }
 
-        String cookieValue = key + "=" + value;
+        String cookieExpiration = "";
+        if (expires != null) {
+            cookieExpiration = "; Expires=" + expires.replaceAll("(?i)Expires=", "");
+        } else if (ageDays != null) {
+            int maxAgeSec = ageDays * 24 * 60 * 60;
+            cookieExpiration = "; Max-Age=" + maxAgeSec;
+        }
+
+        String cookieValue = key + "=" + value + cookieExpiration;
 
         cookieManager.setCookie(url, cookieValue);
 

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -161,13 +161,23 @@ public class CAPHttpPlugin: CAPPlugin {
     guard let urlString = call.getString("url") else {
       return call.reject("Must provide URL")
     }
+    let expires = call.getString("expires")
+    let ageDays = call.getInt("ageDays")
+    
+    var cookieExpiration = ""
+    if expires != nil {
+        cookieExpiration = "; Expires=" + expires!.replacingOccurrences(of: "Expires=", with: "", options:.caseInsensitive)
+    } else if ageDays != nil {
+        let maxAge = ageDays! * 24 * 60 * 60;
+        cookieExpiration = "; Max-Age=\(maxAge)"
+    }
     
     guard let url = URL(string: urlString) else {
       return call.reject("Invalid URL")
     }
     
     let jar = HTTPCookieStorage.shared
-    let field = ["Set-Cookie": "\(key)=\(value)"]
+    let field = ["Set-Cookie": "\(key)=\(value)\(cookieExpiration)"]
     let cookies = HTTPCookie.cookies(withResponseHeaderFields: field, for: url)
     jar.setCookies(cookies, for: url, mainDocumentURL: url)
     

--- a/src/web.ts
+++ b/src/web.ts
@@ -121,7 +121,7 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
     var expires = '';
     if (options.expires) {
       // remove "expires=" so you can pass with or without the prefix
-      expires = `; expires=${options.expires.replace('expires=', '')}`;
+      expires = `; expires=${options.expires.replace(/expires=/gi, '')}`;
     } else if (options.ageDays) {
       const date = new Date();
       date.setTime(date.getTime() + options.ageDays * 24 * 60 * 60 * 1000);
@@ -193,9 +193,9 @@ export class HttpPluginWeb extends WebPlugin implements HttpPlugin {
     const fetchOptions = this.makeFetchOptions(options, options.webFetchExtra);
 
     const ret = await fetch(options.url, fetchOptions);
-    
-    if(!ret.ok) {
-      return Promise.reject("Download file error: response not ok")
+
+    if (!ret.ok) {
+      return Promise.reject('Download file error: response not ok');
     }
 
     const blob = await ret.blob();


### PR DESCRIPTION
Currently, setting the cookie expiration via the `expires` or `ageDays` params does only work in the web version.
This PR adds the same functionality to the android/ios versions.
In addition, this PR updates the setCookies method in the web version to use case-insensitive replacement.