### PR TITLE
Add additional logic for FormData typed request bodies

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -89,8 +89,14 @@ export const buildRequestInit = (
     typeof options.data === 'object'
   ) {
     const form = new FormData();
-    for (const [key, value] of Object.entries(options.data || {})) {
-      form.append(key, value as any);
+    if (options.data instanceof FormData) {
+      options.data.forEach((value, key) => {
+        form.append(key, value);
+      });
+    } else {
+      for (let key of Object.keys(options.data)) {
+        form.append(key, options.data[key]);
+      }
     }
     output.body = form;
   }


### PR DESCRIPTION
The current web implementation seems to not include anything in the request body if the data property is a FormData object. In my opinion, the problem lays in iterating over the FormData content using Object.keys(), which doesn't seem to return anything for a FormData object. My suggestion is to use a separate FormData specific method to iterate over the FormData content.

-Since Object.keys() doesn't return anything for FormData typed objects, use a FormData specific function to iterate over the key/value pairs.