### PR TITLE
Adding support for posting json arrays.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ android-template/app/app.iml
 build/
 capacitor-cordova-ios-plugins
 example/ios/App/public
+/.vs

--- a/android/src/main/java/com/getcapacitor/plugin/http/CapacitorHttpUrlConnection.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/CapacitorHttpUrlConnection.java
@@ -1,6 +1,9 @@
 package com.getcapacitor.plugin.http;
 
+import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.PluginCall;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -150,18 +153,31 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
 
     /**
      *
-     * @param body
+     * @param call
      * @throws JSONException
      * @throws IOException
      */
-    public void setRequestBody(JSObject body) throws JSONException, IOException {
+    public void setRequestBody(PluginCall call) throws JSONException, IOException {
         String contentType = connection.getRequestProperty("Content-Type");
+
+        JSObject body = call.getObject("data", null);
 
         if (contentType == null || contentType.isEmpty()) return;
 
         String dataString = "";
         if (contentType.contains("application/json")) {
-            dataString = body.toString();
+            JSArray jsArray = null;
+            if (body != null) {
+                dataString = body.toString();
+            } else {
+                jsArray = call.getArray("data", null);
+            }
+            if (jsArray != null) {
+                dataString = jsArray.toString();
+            } else if(body == null) {
+                String anything = call.getString("data");
+                dataString = anything;
+            }
         } else if (contentType.contains("application/x-www-form-urlencoded")) {
             StringBuilder builder = new StringBuilder();
             Iterator<String> keys = body.keys();

--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -275,9 +275,13 @@ public class HttpRequestHandler {
     private static String readStreamAsString(InputStream in) throws IOException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
             StringBuilder builder = new StringBuilder();
-            String line;
-            while ((line = reader.readLine()) != null) {
-                builder.append(line).append(System.getProperty("line.separator"));
+            String line = reader.readLine();
+            while (line != null) {
+                builder.append(line);
+                line = reader.readLine();
+                if (line != null){
+                    builder.append(System.getProperty("line.separator"));
+                }
             }
             return builder.toString();
         }

--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -319,9 +319,8 @@ public class HttpRequestHandler {
 
         // Set HTTP body on a non GET or HEAD request
         if (isHttpMutate) {
-            JSObject data = call.getObject("data");
             connection.setDoOutput(true);
-            connection.setRequestBody(data);
+            connection.setRequestBody(call);
         }
 
         connection.connect();

--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -7,6 +7,8 @@ import android.content.Context;
 import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
+import android.util.MutableBoolean;
+
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
@@ -174,24 +176,30 @@ public class HttpRequestHandler {
 
     private static JSObject buildResponse(CapacitorHttpUrlConnection connection, ResponseType responseType)
         throws IOException, JSONException {
+        MutableBoolean isError = new MutableBoolean(false);
         int statusCode = connection.getResponseCode();
 
         JSObject output = new JSObject();
         output.put("status", statusCode);
         output.put("headers", buildResponseHeaders(connection));
         output.put("url", connection.getURL());
-        output.put("data", readData(connection, responseType));
+        output.put("data", readData(connection, responseType, isError));
+
+        if(isError.value){
+            output.put("error", true);
+        }
 
         // Log.d(getLogTag(), "Request completed, got data");
 
         return output;
     }
 
-    static Object readData(ICapacitorHttpUrlConnection connection, ResponseType responseType) throws IOException, JSONException {
+    static Object readData(ICapacitorHttpUrlConnection connection, ResponseType responseType, MutableBoolean isError) throws IOException, JSONException {
         InputStream errorStream = connection.getErrorStream();
         String contentType = connection.getHeaderField("Content-Type");
 
         if (errorStream != null) {
+            isError.value = true;
             if (isOneOf(contentType, APPLICATION_JSON, APPLICATION_VND_API_JSON)) {
                 return parseJSON(readStreamAsString(errorStream));
             } else {

--- a/android/src/test/java/com/getcapacitor/plugin/http/HttpRequestHandlerTest.java
+++ b/android/src/test/java/com/getcapacitor/plugin/http/HttpRequestHandlerTest.java
@@ -1,5 +1,7 @@
 package com.getcapacitor.plugin.http;
 
+import android.util.MutableBoolean;
+
 import com.getcapacitor.JSObject;
 
 import org.json.JSONException;
@@ -20,33 +22,42 @@ public class HttpRequestHandlerTest {
 
     @Test
     public void readData_error_with_HTML_message() throws IOException, JSONException {
+        MutableBoolean isError = new MutableBoolean(false);
         String result = (String) HttpRequestHandler.readData(
                 errorWithHtmlMessage("html-error"),
-                JSON);
+                JSON,
+                isError);
 
-        assertEquals("html-error\n", result);
+        assertEquals("html-error", result);
+        assertEquals(isError.value, true);
     }
 
     @Test
     public void readData_error_with_JSON() throws IOException, JSONException {
+        MutableBoolean isError = new MutableBoolean(false);
         JSObject jsonObject = new JSObject("{ 'message' : 'Hello world!' }");
 
         JSObject result = (JSObject) HttpRequestHandler.readData(
                 errorWithJson(jsonObject),
-                JSON);
+                JSON,
+                isError);
 
         assertEquals(jsonObject.toString(), result.toString());
+        assertEquals(isError.value, true);
     }
 
     @Test
     public void readData_success_with_JSON() throws IOException, JSONException {
+        MutableBoolean isError = new MutableBoolean(false);
         JSObject jsonObject = new JSObject("{ 'message' : 'Hello world!' }");
 
         JSObject result = (JSObject) HttpRequestHandler.readData(
                 successWithJson(jsonObject),
-                JSON);
+                JSON,
+                isError);
 
         assertEquals(jsonObject.toString(), result.toString());
+        assertEquals(isError.value, false);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/ios/Plugin/CapacitorUrlRequest.swift
+++ b/ios/Plugin/CapacitorUrlRequest.swift
@@ -10,12 +10,13 @@ public class CapacitorUrlRequest {
         request.httpMethod = method
         headers = [:]
     }
-    
+
     private func getRequestDataAsJson(_ data: [String: Any]) throws -> Data? {
-      let jsonData = try JSONSerialization.data(withJSONObject: data)
+      let arrayRequest = data["arrayRequest"];
+      let jsonData = try JSONSerialization.data(withJSONObject: arrayRequest ?? data)
       return jsonData
     }
-    
+
     private func getRequestDataAsFormUrlEncoded(_ data: [String: Any]) -> Data? {
         guard var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false) else { return nil }
         components.queryItems = []
@@ -29,20 +30,20 @@ public class CapacitorUrlRequest {
 
         return nil
     }
-    
+
     private func getRequestDataAsMultipartFormData(_ data: [String: Any]) -> Data? {
         return nil
     }
-    
+
     func getRequestHeader(_ index: String) -> Any? {
         var normalized = [:] as [String:Any]
         self.headers.keys.forEach { (key: String) in
             normalized[key.lowercased()] = self.headers[key]
         }
-        
+
         return normalized[index.lowercased()]
     }
-    
+
     func getRequestData(_ body: [String: Any], _ contentType: String) throws -> Data? {
         if contentType.contains("application/json") {
             return try getRequestDataAsJson(body)
@@ -53,16 +54,16 @@ public class CapacitorUrlRequest {
         }
         return nil
     }
-    
+
     public func setRequestHeaders(_ headers: [String: String]) {
         headers.keys.forEach { (key: String) in
             let value = headers[key]
             request.addValue(value!, forHTTPHeaderField: key)
         }
-        
+
         self.headers = headers;
     }
-    
+
     public func setRequestBody(_ body: [String: Any]) {
         let contentType = self.getRequestHeader("Content-Type") as? String
 
@@ -70,15 +71,15 @@ public class CapacitorUrlRequest {
             request.httpBody = try? getRequestData(body, contentType!)
         }
     }
-    
+
     public func setContentType(_ data: String?) {
         request.setValue(data, forHTTPHeaderField: "Content-Type")
     }
-    
+
     public func setTimeout(_ timeout: TimeInterval) {
         request.timeoutInterval = timeout;
     }
-    
+
     public func getUrlRequest() -> URLRequest {
         return request;
     }

--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -8,20 +8,20 @@ fileprivate enum ResponseType: String {
     case document = "document"
     case json = "json"
     case text = "text"
-    
+
     static let `default`: ResponseType = .text
-    
+
     init(string: String?) {
         guard let string = string else {
             self = .default
             return
         }
-        
+
         guard let responseType = ResponseType(rawValue: string.lowercased()) else {
             self = .default
             return
         }
-        
+
         self = responseType
     }
 }
@@ -44,7 +44,7 @@ class HttpRequestHandler {
         private var method: String?
         private var params: [String:String]?
         private var request: CapacitorUrlRequest?
-        
+
         /// Set the URL of the HttpRequest
         /// - Throws: an error of URLError if the urlString cannot be parsed
         /// - Parameters:
@@ -62,14 +62,14 @@ class HttpRequestHandler {
             self.method = method;
             return self
         }
-        
+
         public func setUrlParams(_ params: [String:Any]) -> CapacitorHttpRequestBuilder {
             if (params.count != 0) {
                 var cmps = URLComponents(url: url!, resolvingAgainstBaseURL: true)
                 if cmps?.queryItems == nil {
                     cmps?.queryItems = []
                 }
-                
+
                 var urlSafeParams: [URLQueryItem] = []
                 for (key, value) in params {
                     if let arr = value as? [String] {
@@ -80,37 +80,37 @@ class HttpRequestHandler {
                         urlSafeParams.append(URLQueryItem(name: key, value: (value as! String)))
                     }
                 }
-                
+
                 cmps!.queryItems?.append(contentsOf: urlSafeParams)
                 url = cmps!.url!
             }
             return self
         }
-        
+
         public func openConnection() -> CapacitorHttpRequestBuilder {
             request = CapacitorUrlRequest(url!, method: method!)
             return self
         }
-        
+
         public func build() -> CapacitorUrlRequest {
             return request!
         }
     }
-    
+
     private static func buildResponse(_ data: Data?, _ response: HTTPURLResponse, responseType: ResponseType = .default) -> [String:Any] {
         var output = [:] as [String:Any]
-      
+
         output["status"] = response.statusCode
         output["headers"] = response.allHeaderFields
         output["url"] = response.url?.absoluteString
-      
+
         guard let data = data else {
             output["data"] = ""
             return output
         }
-      
+
         let contentType = (response.allHeaderFields["Content-Type"] as? String ?? "application/default").lowercased();
-        
+
         if (contentType.contains("application/json") || responseType == .json) {
             output["data"] = tryParseJson(data);
         } else if (responseType == .arrayBuffer || responseType == .blob) {
@@ -121,12 +121,12 @@ class HttpRequestHandler {
 
         return output
     }
-    
+
     private static func generateMultipartForm(_ url: URL, _ name: String, _ boundary: String, _ body: [String:Any]) throws -> Data {
         let strings: [String: String] = body.compactMapValues { any in
             any as? String
         }
-        
+
         var data = Data()
 
         let fileData = try Data(contentsOf: url)
@@ -153,36 +153,44 @@ class HttpRequestHandler {
     public static func request(_ call: CAPPluginCall) throws {
         guard let urlString = call.getString("url") else { throw URLError(.badURL) }
         guard let method = call.getString("method") else { throw URLError(.dataNotAllowed) }
-        
+
         let headers = (call.getObject("headers") ?? [:]) as! [String: String]
         let params = (call.getObject("params") ?? [:]) as! [String: Any]
         let responseType = call.getString("responseType") ?? "text";
         let connectTimeout = call.getDouble("connectTimeout");
         let readTimeout = call.getDouble("readTimeout");
-        
+
         let isHttpMutate = method == "DELETE" ||
             method == "PATCH" ||
             method == "POST" ||
             method == "PUT";
-        
+
         let request = try! CapacitorHttpRequestBuilder()
             .setUrl(urlString)
             .setMethod(method)
             .setUrlParams(params)
             .openConnection()
             .build();
-        
+
         request.setRequestHeaders(headers)
-        
+
         // Timeouts in iOS are in seconds. So read the value in millis and divide by 1000
         let timeout = (connectTimeout ?? readTimeout ?? 600000.0) / 1000.0;
         request.setTimeout(timeout)
-        
+
         if isHttpMutate {
-            let data = call.getObject("data") ?? [:]
+            var data = call.getObject("data") ?? [:]
+
+            if (data.isEmpty) {
+                let jArray = call.getArray("data", (Any).self)
+                if(jArray != nil) {
+                    data["arrayRequest"] = jArray
+                }
+            }
+
             request.setRequestBody(data)
         }
-        
+
         let urlRequest = request.getUrlRequest();
         let task = URLSession.shared.dataTask(with: urlRequest) { (data, response, error) in
             if error != nil {
@@ -193,10 +201,10 @@ class HttpRequestHandler {
             let type = ResponseType(rawValue: responseType) ?? .default
             call.resolve(self.buildResponse(data, response as! HTTPURLResponse, responseType: type))
         }
-        
+
         task.resume();
     }
-    
+
     public static func upload(_ call: CAPPluginCall) throws {
         let name = call.getString("name") ?? "file"
         let method = call.getString("method") ?? "POST"
@@ -207,29 +215,29 @@ class HttpRequestHandler {
         let responseType = call.getString("responseType") ?? "text";
         let connectTimeout = call.getDouble("connectTimeout");
         let readTimeout = call.getDouble("readTimeout");
-        
+
         guard let urlString = call.getString("url") else { throw URLError(.badURL) }
         guard let filePath = call.getString("filePath") else { throw URLError(.badURL) }
         guard let fileUrl = FilesystemUtils.getFileUrl(filePath, fileDirectory) else { throw URLError(.badURL) }
-        
+
         let request = try! CapacitorHttpRequestBuilder()
             .setUrl(urlString)
             .setMethod(method)
             .setUrlParams(params)
             .openConnection()
             .build();
-        
+
         request.setRequestHeaders(headers)
-        
+
         // Timeouts in iOS are in seconds. So read the value in millis and divide by 1000
         let timeout = (connectTimeout ?? readTimeout ?? 600000.0) / 1000.0;
         request.setTimeout(timeout)
-        
+
         let boundary = UUID().uuidString
         request.setContentType("multipart/form-data; boundary=\(boundary)");
 
         guard let form = try? generateMultipartForm(fileUrl, name, boundary, body) else { throw URLError(.cannotCreateFile) }
-        
+
         let urlRequest = request.getUrlRequest();
         let task = URLSession.shared.uploadTask(with: urlRequest, from: form) { (data, response, error) in
             if error != nil {
@@ -243,7 +251,7 @@ class HttpRequestHandler {
 
         task.resume()
     }
-    
+
     public static func download(_ call: CAPPluginCall) throws {
         let method = call.getString("method") ?? "GET"
         let fileDirectory = call.getString("fileDirectory") ?? "DOCUMENTS"
@@ -251,7 +259,7 @@ class HttpRequestHandler {
         let params = (call.getObject("params") ?? [:]) as! [String: Any]
         let connectTimeout = call.getDouble("connectTimeout");
         let readTimeout = call.getDouble("readTimeout");
-        
+
         guard let urlString = call.getString("url") else { throw URLError(.badURL) }
         guard let filePath = call.getString("filePath") else { throw URLError(.badURL) }
 
@@ -261,9 +269,9 @@ class HttpRequestHandler {
             .setUrlParams(params)
             .openConnection()
             .build();
-        
+
         request.setRequestHeaders(headers)
-        
+
         // Timeouts in iOS are in seconds. So read the value in millis and divide by 1000
         let timeout = (connectTimeout ?? readTimeout ?? 600000.0) / 1000.0;
         request.setTimeout(timeout)


### PR DESCRIPTION
### Android:
- Array request support
- Removing the extra new line from the plain text responses.
- Adding error property to response sent from plugin. 

### ios:
- Array request support - there is probably better solution (maybe pushing plugin call variable down through methods) but this also works. As I am not experienced with swift tried to do as less mods as possible.
- There was no extra new line issue 
- I did not include error property for ios as existing implementations in ios and android are not the same (as I can see).



### Thing to consider:
I don't have experience with java/swift but as I understood the code response implementations are not the same:
- Android plugin resolves (call.resolve) http errors - reads error stream and returns json object from readData
- ios plugin rejects (call.reject) http errors - if error occurs plugin call result is empty
- Android plugin has {"ok":false} for http errors but ios does not have the same field.

I hope this make sense.

 