### PR TITLE
(iOS) Fix: Allow non-object request bodies

### DIFF
--- a/ios/Plugin/CapacitorUrlRequest.swift
+++ b/ios/Plugin/CapacitorUrlRequest.swift
@@ -41,7 +41,7 @@ public class CapacitorUrlRequest {
         return nil
     }
     
-    private func getRequestDataAsMultipartFormData(_ data: JSValue) throws -> Data? {
+    private func getRequestDataAsMultipartFormData(_ data: JSValue) throws -> Data {
         guard let obj = data as? JSObject else {
             // Throw, other data types explicitly not supported.
             throw CapacitorUrlRequestError.serializationError("[ data ] argument for request with content-type [ application/x-www-form-urlencoded ] may only be a plain javascript object")
@@ -67,6 +67,13 @@ public class CapacitorUrlRequest {
         return data
     }
     
+    private func getRequestDataAsString(_ data: JSValue) throws -> Data {
+        guard let stringData = data as? String else {
+            throw CapacitorUrlRequestError.serializationError("[ data ] argument could not be parsed as string")
+        }
+        return Data(stringData.utf8)
+    }
+    
     func getRequestHeader(_ index: String) -> Any? {
         var normalized = [:] as [String:Any]
         self.headers.keys.forEach { (key: String) in
@@ -83,8 +90,9 @@ public class CapacitorUrlRequest {
             return try getRequestDataAsFormUrlEncoded(body)
         } else if contentType.contains("multipart/form-data") {
             return try getRequestDataAsMultipartFormData(body)
+        } else {
+            return try getRequestDataAsString(body)
         }
-        return nil
     }
     
     public func setRequestHeaders(_ headers: [String: String]) {

--- a/ios/Plugin/CapacitorUrlRequest.swift
+++ b/ios/Plugin/CapacitorUrlRequest.swift
@@ -31,7 +31,24 @@ public class CapacitorUrlRequest {
     }
     
     private func getRequestDataAsMultipartFormData(_ data: [String: Any]) -> Data? {
-        return nil
+        let strings: [String: String] = data.compactMapValues { any in
+            any as? String
+        }
+        
+        var data = Data()
+        let boundary = UUID().uuidString
+        let contentType = "multipart/form-data; boundary=\(boundary)"
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        headers["Content-Type"] = contentType
+        
+        strings.forEach { key, value in
+            data.append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
+            data.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".data(using: .utf8)!)
+            data.append(value.data(using: .utf8)!)
+        }
+        data.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        
+        return data
     }
     
     func getRequestHeader(_ index: String) -> Any? {

--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -179,8 +179,19 @@ class HttpRequestHandler {
         request.setTimeout(timeout)
         
         if isHttpMutate {
-            let data = call.getObject("data") ?? [:]
-            request.setRequestBody(data)
+            do {
+                guard let data = call.jsObjectRepresentation["data"]
+                else {
+                    throw CapacitorUrlRequest.CapacitorUrlRequestError.serializationError("Invalid [ data ] argument")
+                }
+                
+                try request.setRequestBody(data)
+            } catch {
+                // Explicitly reject if the http request body was not set successfully,
+                // so as to not send a known malformed request, and to provide the developer with additional context.
+                call.reject("Error", "REQUEST", error, [:])
+                return;
+            }
         }
         
         let urlRequest = request.getUrlRequest();


### PR DESCRIPTION
This change moves parsing the "data" arg from JSValue into more specific types further down into the content-type specific handlers. The abstract capacitor `JSValue` is suitable for passing to the JSON serializer, so by doing this, we fix POST/PATCH/etc on iOS for data structures other than objects/dictionaries. This was important to me as I need to send an array as my POST body.

Additionally, when the request body sent to this plugin is improperly formed, we now explicitly throw before even making the request. This is both to ensure we don't send a malformed request, and also to provide the developer with some insight as to where and why the request is failing (specifically, I always want to know if the plugin is generating the error, or if the server is generating the error. Setting a null request body and then sending the request and getting a 500 is misleading to the developer). As part of this change, we also now always try to parse the request body as a string as a fallback, even if it's not of a whitelisted content-type.

Depends on #139, as there would be merge conflicts otherwise, and I don't see that one being problematic.  
Fixes #43 (unless this is also an issue on android, I haven't checked yet)