### PR TITLE
(Android) Fix: Allow non-object request bodies

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/CapacitorHttpUrlConnection.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/CapacitorHttpUrlConnection.java
@@ -159,9 +159,8 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
 
         if (contentType == null || contentType.isEmpty()) return;
 
-        String dataString = "";
         if (contentType.contains("application/json")) {
-            dataString = body.toString();
+            this.writeRequestBody(body.toString());
         } else if (contentType.contains("application/x-www-form-urlencoded")) {
             StringBuilder builder = new StringBuilder();
 
@@ -176,7 +175,7 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
                     builder.append("&");
                 }
             }
-            dataString = builder.toString();
+            this.writeRequestBody(builder.toString());
         } else if (contentType.contains("multipart/form-data")) {
             FormUploader uploader = new FormUploader(connection);
 
@@ -189,13 +188,19 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
                 uploader.addFormField(key, d);
             }
             uploader.finish();
-            dataString = body.toString();
         } else {
-            dataString = body.toString();
+            this.writeRequestBody(body.toString());
         }
+    }
 
+    /**
+     * Writes the provided string to the HTTP connection managed by this instance.
+     *
+     * @param body The string value to write to the connection stream.
+     */
+    private void writeRequestBody(String body) throws IOException {
         try (DataOutputStream os = new DataOutputStream(connection.getOutputStream())) {
-            os.write(dataString.getBytes(StandardCharsets.UTF_8));
+            os.write(body.getBytes(StandardCharsets.UTF_8));
             os.flush();
         }
     }

--- a/android/src/main/java/com/getcapacitor/plugin/http/CapacitorHttpUrlConnection.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/CapacitorHttpUrlConnection.java
@@ -154,7 +154,7 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
      * @throws JSONException
      * @throws IOException
      */
-    public void setRequestBody(JSObject body) throws JSONException, IOException {
+    public void setRequestBody(JSValue body) throws JSONException, IOException {
         String contentType = connection.getRequestProperty("Content-Type");
 
         if (contentType == null || contentType.isEmpty()) return;
@@ -164,10 +164,12 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
             dataString = body.toString();
         } else if (contentType.contains("application/x-www-form-urlencoded")) {
             StringBuilder builder = new StringBuilder();
-            Iterator<String> keys = body.keys();
+
+            JSObject obj = body.toJSObject();
+            Iterator<String> keys = obj.keys();
             while (keys.hasNext()) {
                 String key = keys.next();
-                Object d = body.get(key);
+                Object d = obj.get(key);
                 builder.append(key).append("=").append(URLEncoder.encode(d.toString(), "UTF-8"));
 
                 if (keys.hasNext()) {
@@ -178,14 +180,17 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
         } else if (contentType.contains("multipart/form-data")) {
             FormUploader uploader = new FormUploader(connection);
 
-            Iterator<String> keys = body.keys();
+            JSObject obj = body.toJSObject();
+            Iterator<String> keys = obj.keys();
             while (keys.hasNext()) {
                 String key = keys.next();
 
-                String d = body.get(key).toString();
+                String d = obj.get(key).toString();
                 uploader.addFormField(key, d);
             }
             uploader.finish();
+            dataString = body.toString();
+        } else {
             dataString = body.toString();
         }
 

--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -109,15 +109,9 @@ public class Http extends Plugin {
                     try {
                         JSObject response = HttpRequestHandler.request(call);
                         call.resolve(response);
-                    } catch (IOException e) {
+                    } catch (Exception e) {
                         System.out.println(e.toString());
-                        call.reject("IO Exception");
-                    } catch (URISyntaxException e) {
-                        System.out.println(e.toString());
-                        call.reject("URI Syntax Exception");
-                    } catch (JSONException e) {
-                        System.out.println(e.toString());
-                        call.reject("JSON Exception");
+                        call.reject(e.getClass().getSimpleName(), e);
                     }
                 }
             }

--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -4,6 +4,7 @@ import static com.getcapacitor.plugin.http.MimeType.APPLICATION_JSON;
 import static com.getcapacitor.plugin.http.MimeType.APPLICATION_VND_API_JSON;
 
 import android.content.Context;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
@@ -17,6 +18,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.NotSerializableException;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -315,9 +318,11 @@ public class HttpRequestHandler {
 
         // Set HTTP body on a non GET or HEAD request
         if (isHttpMutate) {
-            JSObject data = call.getObject("data");
-            connection.setDoOutput(true);
-            connection.setRequestBody(data);
+            JSValue data = new JSValue(call, "data");
+            if (data.getValue() != null) {
+                connection.setDoOutput(true);
+                connection.setRequestBody(data);
+            }
         }
 
         connection.connect();

--- a/android/src/main/java/com/getcapacitor/plugin/http/JSValue.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/JSValue.java
@@ -1,0 +1,68 @@
+package com.getcapacitor.plugin.http;
+
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.PluginCall;
+import org.json.JSONException;
+
+/**
+ * Represents a single user-data value of any type on the capacitor PluginCall object.
+ */
+public class JSValue {
+
+    private final Object value;
+
+    /**
+     * @param call The capacitor plugin call, used for accessing the value safely.
+     * @param name The name of the property to access.
+     */
+    public JSValue(PluginCall call, String name) {
+        this.value = this.toValue(call, name);
+    }
+
+    /**
+     * Returns the coerced but uncasted underlying value.
+     */
+    public Object getValue() {
+        return this.value;
+    }
+
+    @Override
+    public String toString() {
+        return this.getValue().toString();
+    }
+
+    /**
+     * Returns the underlying value as a JSObject, or throwing if it cannot.
+     *
+     * @throws JSONException If the underlying value is not a JSObject.
+     */
+    public JSObject toJSObject() throws JSONException {
+        if (this.value instanceof JSObject) return (JSObject) this.value;
+        throw new JSONException("JSValue could not be coerced to JSObject.");
+    }
+
+    /**
+     * Returns the underlying value as a JSArray, or throwing if it cannot.
+     *
+     * @throws JSONException If the underlying value is not a JSArray.
+     */
+    public JSArray toJSArray() throws JSONException {
+        if (this.value instanceof JSArray) return (JSArray) this.value;
+        throw new JSONException("JSValue could not be coerced to JSArray.");
+    }
+
+    /**
+     * Returns the underlying value this object represents, coercing it into a capacitor-friendly object if supported.
+     */
+    private Object toValue(PluginCall call, String name) {
+        Object value = null;
+        value = call.getArray(name, null);
+        if (value != null) return value;
+        value = call.getObject(name, null);
+        if (value != null) return value;
+        value = call.getString(name, null);
+        if (value != null) return value;
+        return call.getData().opt(name);
+    }
+}

--- a/ios/Plugin/CapacitorUrlRequest.swift
+++ b/ios/Plugin/CapacitorUrlRequest.swift
@@ -41,7 +41,7 @@ public class CapacitorUrlRequest {
         return nil
     }
     
-    private func getRequestDataAsMultipartFormData(_ data: JSValue) throws -> Data? {
+    private func getRequestDataAsMultipartFormData(_ data: JSValue) throws -> Data {
         guard let obj = data as? JSObject else {
             // Throw, other data types explicitly not supported.
             throw CapacitorUrlRequestError.serializationError("[ data ] argument for request with content-type [ application/x-www-form-urlencoded ] may only be a plain javascript object")
@@ -67,6 +67,13 @@ public class CapacitorUrlRequest {
         return data
     }
     
+    private func getRequestDataAsString(_ data: JSValue) throws -> Data {
+        guard let stringData = data as? String else {
+            throw CapacitorUrlRequestError.serializationError("[ data ] argument could not be parsed as string")
+        }
+        return Data(stringData.utf8)
+    }
+    
     func getRequestHeader(_ index: String) -> Any? {
         var normalized = [:] as [String:Any]
         self.headers.keys.forEach { (key: String) in
@@ -83,8 +90,9 @@ public class CapacitorUrlRequest {
             return try getRequestDataAsFormUrlEncoded(body)
         } else if contentType.contains("multipart/form-data") {
             return try getRequestDataAsMultipartFormData(body)
+        } else {
+            return try getRequestDataAsString(body)
         }
-        return nil
     }
     
     public func setRequestHeaders(_ headers: [String: String]) {

--- a/ios/Plugin/CapacitorUrlRequest.swift
+++ b/ios/Plugin/CapacitorUrlRequest.swift
@@ -31,7 +31,24 @@ public class CapacitorUrlRequest {
     }
     
     private func getRequestDataAsMultipartFormData(_ data: [String: Any]) -> Data? {
-        return nil
+        let strings: [String: String] = data.compactMapValues { any in
+            any as? String
+        }
+        
+        var data = Data()
+        let boundary = UUID().uuidString
+        let contentType = "multipart/form-data; boundary=\(boundary)"
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        headers["Content-Type"] = contentType
+        
+        strings.forEach { key, value in
+            data.append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
+            data.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".data(using: .utf8)!)
+            data.append(value.data(using: .utf8)!)
+        }
+        data.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        
+        return data
     }
     
     func getRequestHeader(_ index: String) -> Any? {

--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -179,8 +179,19 @@ class HttpRequestHandler {
         request.setTimeout(timeout)
         
         if isHttpMutate {
-            let data = call.getObject("data") ?? [:]
-            request.setRequestBody(data)
+            do {
+                guard let data = call.jsObjectRepresentation["data"]
+                else {
+                    throw CapacitorUrlRequest.CapacitorUrlRequestError.serializationError("Invalid [ data ] argument")
+                }
+                
+                try request.setRequestBody(data)
+            } catch {
+                // Explicitly reject if the http request body was not set successfully,
+                // so as to not send a known malformed request, and to provide the developer with additional context.
+                call.reject("Error", "REQUEST", error, [:])
+                return;
+            }
         }
         
         let urlRequest = request.getUrlRequest();


### PR DESCRIPTION
Does essentially the same as #141, but for android. The primary use-case for this is to be able to send content-type: application/json requests that _are_ valid JSON, but aren't plain objects (such as arrays and JS primitives).

Additionally, this fixes an existing bug where for multipart/form-data requests, the connection stream was being written to after it was closed, causing an IOException.