### PR TITLE
fix http method helper functions on ios

### DIFF
--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -150,9 +150,9 @@ class HttpRequestHandler {
     }
 
 
-    public static func request(_ call: CAPPluginCall) throws {
+    public static func request(_ call: CAPPluginCall, _ httpMethod: String?) throws {
         guard let urlString = call.getString("url") else { throw URLError(.badURL) }
-        guard let method = call.getString("method") else { throw URLError(.dataNotAllowed) }
+        guard let method = httpMethod ?? call.getString("method") else { throw URLError(.dataNotAllowed) }
 
         let headers = (call.getObject("headers") ?? [:]) as! [String: String]
         let params = (call.getObject("params") ?? [:]) as! [String: Any]

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -27,7 +27,7 @@ import Foundation
         guard var _ = URL(string: u) else { return call.reject("Invalid URL"); }
     
         do {
-            try HttpRequestHandler.request(call)
+            try HttpRequestHandler.request(call, httpMethod)
         } catch let e {
             call.reject(e.localizedDescription)
         }


### PR DESCRIPTION
http method utility functions (ie: `Http.get({url: ''})`) do not currently work on iOS, the http method is not passed through to `HttpRequestHandler.request` properly and it throws `.dataNotAllowed`