### PR TITLE
Fix "getCookie" on ios

### DIFF
--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -10,6 +10,7 @@ CAP_PLUGIN(HttpPlugin, "Http",
   CAP_PLUGIN_METHOD(del, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(setCookie, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getCookies, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(getCookie, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(deleteCookie, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(clearCookies, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(downloadFile, CAPPluginReturnPromise);


### PR DESCRIPTION
Currently, executing "getCookie()" on ios throws the followeing error: "getCookie() is not implemented on ios".
This PR fixes this issue.