### PR TITLE
Add support for disabling automatic HTTP redirects on android/ios

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/CapacitorHttpUrlConnection.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/CapacitorHttpUrlConnection.java
@@ -123,6 +123,14 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
     }
 
     /**
+     * Sets whether automatic HTTP redirects should be disabled
+     * @param disableRedirects the flag to determine if redirects should be followed
+     */
+    public void setDisableRedirects(boolean disableRedirects) {
+        connection.setInstanceFollowRedirects(!disableRedirects);
+    }
+
+    /**
      * Sets the request headers given a JSObject of key-value pairs
      * @param headers the JSObject values to map to the HttpUrlConnection request headers
      */

--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -66,6 +66,7 @@ public class HttpRequestHandler {
 
         private Integer connectTimeout;
         private Integer readTimeout;
+        private Boolean disableRedirects;
         private JSObject headers;
         private String method;
         private URL url;
@@ -79,6 +80,11 @@ public class HttpRequestHandler {
 
         public HttpURLConnectionBuilder setReadTimeout(Integer readTimeout) {
             this.readTimeout = readTimeout;
+            return this;
+        }
+
+        public HttpURLConnectionBuilder setDisableRedirects(Boolean disableRedirects) {
+            this.disableRedirects = disableRedirects;
             return this;
         }
 
@@ -105,6 +111,7 @@ public class HttpRequestHandler {
 
             if (connectTimeout != null) connection.setConnectTimeout(connectTimeout);
             if (readTimeout != null) connection.setReadTimeout(readTimeout);
+            if (disableRedirects != null) connection.setDisableRedirects(disableRedirects);
 
             connection.setRequestHeaders(headers);
             return this;
@@ -354,6 +361,7 @@ public class HttpRequestHandler {
         JSObject params = call.getObject("params");
         Integer connectTimeout = call.getInt("connectTimeout");
         Integer readTimeout = call.getInt("readTimeout");
+        Boolean disableRedirects = call.getBoolean("disableRedirects");
         ResponseType responseType = ResponseType.parse(call.getString("responseType"));
 
         String method = httpMethod != null ? httpMethod.toUpperCase() : call.getString("method", "").toUpperCase();
@@ -368,6 +376,7 @@ public class HttpRequestHandler {
             .setUrlParams(params)
             .setConnectTimeout(connectTimeout)
             .setReadTimeout(readTimeout)
+            .setDisableRedirects(disableRedirects)
             .openConnection();
 
         CapacitorHttpUrlConnection connection = connectionBuilder.build();

--- a/ios/Plugin/CapacitorUrlRequest.swift
+++ b/ios/Plugin/CapacitorUrlRequest.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Capacitor
 
-public class CapacitorUrlRequest {
+public class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
     private var request: URLRequest;
     private var headers: [String:String];
     
@@ -122,5 +122,17 @@ public class CapacitorUrlRequest {
 
     public func getUrlRequest() -> URLRequest {
         return request;
+    }
+    
+    public func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+        completionHandler(nil)
+    }
+
+    public func getUrlSession(_ call: CAPPluginCall) -> URLSession {
+        let disableRedirects = call.getBool("disableRedirects") ?? false
+        if (!disableRedirects) {
+            return URLSession.shared
+        }
+        return URLSession(configuration: URLSessionConfiguration.default, delegate: self, delegateQueue: nil)
     }
 }

--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -195,7 +195,9 @@ class HttpRequestHandler {
         }
 
         let urlRequest = request.getUrlRequest();
-        let task = URLSession.shared.dataTask(with: urlRequest) { (data, response, error) in
+        let urlSession = request.getUrlSession(call);
+        let task = urlSession.dataTask(with: urlRequest) { (data, response, error) in
+            urlSession.invalidateAndCancel();
             if error != nil {
                 call.reject("Error", "REQUEST", error, [:])
                 return;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -39,6 +39,10 @@ export interface HttpOptions {
    */
   connectTimeout?: number;
   /**
+   * Sets whether automatic HTTP redirects should be disabled
+   */
+  disableRedirects?: boolean;
+  /**
    * Extra arguments for fetch when running on the web
    */
   webFetchExtra?: RequestInit;


### PR DESCRIPTION
This PR adds support for disabling automatic HTTP redirects on android/ios by setting the "disableRedirects" property in the HttpOptions object.
This functionality is already provided by the Cordova HTTP plugin [cordova-plugin-advanced-http](https://github.com/silkimen/cordova-plugin-advanced-http).