### PR TITLE
(web) Change content-type "detection" to prioritize application/json

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -76,18 +76,13 @@ export const buildRequestInit = (
   const type = headers['content-type'] || '';
 
   // Build request initializers based off of content-type
-  if (type.includes('application/json')) {
-    output.body = JSON.stringify(options.data);
-  } else if (type.includes('application/x-www-form-urlencoded')) {
+  if (type.includes('application/x-www-form-urlencoded')) {
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(options.data || {})) {
       params.set(key, value as any);
     }
     output.body = params.toString();
-  } else if (
-    type.includes('multipart/form-data') ||
-    typeof options.data === 'object'
-  ) {
+  } else if (type.includes('multipart/form-data')) {
     const form = new FormData();
     if (options.data instanceof FormData) {
       options.data.forEach((value, key) => {
@@ -99,6 +94,14 @@ export const buildRequestInit = (
       }
     }
     output.body = form;
+    const headers = new Headers(output.headers);
+    headers.delete('content-type'); // content-type will be set by `window.fetch` to includy boundary
+    output.headers = headers;
+  } else if (
+    type.includes('application/json') ||
+    typeof options.data === 'object'
+  ) {
+    output.body = JSON.stringify(options.data);
   }
 
   return output;


### PR DESCRIPTION
By default, in the native implementations, if content type is excluded and an object is passed for `data`, the content type will default to `application/json`. However, in the web impl, it defaults to `multipart/form-data`. This change makes the behavior of the web implementation more like the native implementations, so that consumers can do less `platformIs` switching.

I've also included a fix for `multipart/form-data` handling, as it does not work currently.