### PR TITLE
feat: downloadFile progress reporting support

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -390,10 +390,12 @@ public class HttpRequestHandler {
      * Makes an Http Request to download a file based on the PluginCall parameters
      * @param call The Capacitor PluginCall that contains the options need for an Http request
      * @param context The Android Context required for writing to the filesystem
+     * @param progress The emitter which notifies listeners on downloading progression
      * @throws IOException throws an IO request when a connection can't be made
      * @throws URISyntaxException thrown when the URI is malformed
      */
-    public static JSObject downloadFile(PluginCall call, Context context) throws IOException, URISyntaxException, JSONException {
+    public static JSObject downloadFile(PluginCall call, Context context, ProgressEmitter progress)
+        throws IOException, URISyntaxException, JSONException {
         String urlString = call.getString("url");
         String method = call.getString("method", "GET").toUpperCase();
         String filePath = call.getString("filePath");
@@ -420,11 +422,24 @@ public class HttpRequestHandler {
 
         FileOutputStream fileOutputStream = new FileOutputStream(file, false);
 
+        String contentLength = connection.getHeaderField("content-length");
+        int bytes = 0;
+        int maxBytes = 0;
+
+        try {
+            maxBytes = contentLength != null ? Integer.parseInt(contentLength) : 0;
+        } catch (NumberFormatException e) {
+            maxBytes = 0;
+        }
+
         byte[] buffer = new byte[1024];
         int len;
 
         while ((len = connectionInputStream.read(buffer)) > 0) {
             fileOutputStream.write(buffer, 0, len);
+
+            bytes += len;
+            progress.emit(bytes, maxBytes);
         }
 
         connectionInputStream.close();
@@ -479,5 +494,10 @@ public class HttpRequestHandler {
         builder.finish();
 
         return buildResponse(connection, responseType);
+    }
+
+    @FunctionalInterface
+    public interface ProgressEmitter {
+        void emit(Integer bytes, Integer contentLength);
     }
 }

--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -255,13 +255,14 @@ class HttpRequestHandler {
         task.resume()
     }
 
-    public static func download(_ call: CAPPluginCall) throws {
+    public static func download(_ call: CAPPluginCall, updateProgress: @escaping ProgressEmitter) throws {
         let method = call.getString("method") ?? "GET"
         let fileDirectory = call.getString("fileDirectory") ?? "DOCUMENTS"
         let headers = (call.getObject("headers") ?? [:]) as! [String: String]
         let params = (call.getObject("params") ?? [:]) as! [String: Any]
         let connectTimeout = call.getDouble("connectTimeout");
         let readTimeout = call.getDouble("readTimeout");
+        let progress = call.getBool("progress") ?? false
 
         guard let urlString = call.getString("url") else { throw URLError(.badURL) }
         guard let filePath = call.getString("filePath") else { throw URLError(.badURL) }
@@ -279,8 +280,7 @@ class HttpRequestHandler {
         let timeout = (connectTimeout ?? readTimeout ?? 600000.0) / 1000.0;
         request.setTimeout(timeout)
 
-        let urlRequest = request.getUrlRequest()
-        let task = URLSession.shared.downloadTask(with: urlRequest) { (downloadLocation, response, error) in
+        func handleDownload(downloadLocation: URL?, response: URLResponse?, error: Error?) {
             if error != nil {
                 CAPLog.print("Error on download file", String(describing: downloadLocation), String(describing: response), String(describing: error))
                 call.reject("Error", "DOWNLOAD", error, [:])
@@ -314,6 +314,53 @@ class HttpRequestHandler {
             CAPLog.print("Downloaded file", location)
         }
 
+        var session: URLSession!
+        var task: URLSessionDownloadTask!
+        let urlRequest = request.getUrlRequest()
+
+        if progress {
+            class ProgressDelegate : NSObject, URLSessionDataDelegate, URLSessionDownloadDelegate {
+                private var handler: (URL?, URLResponse?, Error?) -> Void;
+                private var downloadLocation: URL?;
+                private var response: URLResponse?;
+                private var emitter: (Int64, Int64) -> Void;
+
+                init(downloadHandler: @escaping (URL?, URLResponse?, Error?) -> Void, progressEmitter: @escaping (Int64, Int64) -> Void) {
+                    handler = downloadHandler
+                    emitter = progressEmitter
+                }
+
+                func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+                    if totalBytesExpectedToWrite > 0 {
+                        emitter(totalBytesWritten, totalBytesExpectedToWrite)
+                    }
+                    else {
+                        emitter(totalBytesWritten, 0)
+                    }
+                }
+
+                func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+                    downloadLocation = location
+                    handler(downloadLocation, downloadTask.response, downloadTask.error)
+                }
+
+                func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+                    if error != nil {
+                        handler(downloadLocation, task.response, error)
+                    }
+                }
+            }
+
+            let progressDelegate = ProgressDelegate(downloadHandler: handleDownload, progressEmitter: updateProgress)
+            session = URLSession(configuration: .default, delegate: progressDelegate, delegateQueue: nil)
+            task = session.downloadTask(with: urlRequest)
+        }
+        else {
+            task = URLSession.shared.downloadTask(with: urlRequest, completionHandler: handleDownload)
+        }
+
         task.resume()
     }
+
+    public typealias ProgressEmitter = (_ bytes: Int64, _ contentLength: Int64) -> Void;
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -63,8 +63,17 @@ import Foundation
         guard let _ = call.getString("filePath") else { return call.reject("Must provide a file path to download the file to") }
         guard let _ = URL(string: u) else { return call.reject("Invalid URL") }
 
+        let progressEmitter: HttpRequestHandler.ProgressEmitter = {bytes, contentLength in
+            self.notifyListeners("progress", data: [
+                "type": "DOWNLOAD",
+                "url": u,
+                "bytes": bytes,
+                "contentLength": contentLength
+            ])
+        }
+
         do {
-            try HttpRequestHandler.download(call)
+            try HttpRequestHandler.download(call, updateProgress: progressEmitter)
         } catch let e {
             call.reject(e.localizedDescription)
         }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -27,6 +27,8 @@ export interface HttpPlugin {
     eventName: 'progress',
     listenerFunc: HttpProgressListener,
   ): Promise<PluginListenerHandle> & PluginListenerHandle;
+
+  removeAllListeners(): Promise<void>;
 }
 
 export interface HttpOptions {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,4 @@
+import type { PluginListenerHandle } from '@capacitor/core';
 import { Directory } from '@capacitor/filesystem';
 
 type HttpResponseType = 'arraybuffer' | 'blob' | 'json' | 'text' | 'document';
@@ -21,6 +22,11 @@ export interface HttpPlugin {
   downloadFile(
     options: HttpDownloadFileOptions,
   ): Promise<HttpDownloadFileResult>;
+
+  addListener(
+    eventName: 'progress',
+    listenerFunc: HttpProgressListener,
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 }
 
 export interface HttpOptions {
@@ -80,6 +86,12 @@ export interface HttpDownloadFileOptions extends HttpOptions {
    * If this option is used, filePath can be a relative path rather than absolute
    */
   fileDirectory?: Directory;
+  /**
+   * Optionally, the switch that enables notifying listeners about downloaded progress
+   *
+   * If this option is used, progress event should be dispatched on every chunk received
+   */
+  progress?: Boolean;
 }
 
 export interface HttpUploadFileOptions extends HttpOptions {
@@ -154,3 +166,14 @@ export interface HttpDownloadFileResult {
 }
 
 export interface HttpUploadFileResult extends HttpResponse {}
+
+export type ProgressType = 'DOWNLOAD' | 'UPLOAD';
+
+export interface ProgressStatus {
+  type: ProgressType;
+  url: string;
+  bytes: number;
+  contentLength: number;
+}
+
+export type HttpProgressListener = (progress: ProgressStatus) => void;


### PR DESCRIPTION
Attempt at **partially** implementing #2 

- [x] web support
- [x] android support
- [x] ios support

### Introduction

The pull requests covers only downloadFile progress (but also places some foundation for uploadFile implementation and maybe even request support) since it seems like the best candidate for checking progress - when we use it we are probably downloading bigger files using it and it was easiest one to implement (no deep buried logic).

Pull request is marked as draft since I'm not sure if it should or can be merged without at least uploadFile support.
Will also try to implement ios support after getting convention/implementation/approval feedback.

For downloadFile only support we can drop generic interfaces in favor of ones like `download-progress` event or just only use `DOWNLOAD` ProgressType. 

Naming conventions and implementation methods of course are subject to change based on feedback.

This draft might aswell go nowhere if it's not good enough, no hard feelings :)

### Usage

```typescript
Http.addListener("progress", (e) => {
  console.log(e.type);
  console.log(e.url);
  console.log(e.bytes + " / " + e.contentLength);
});


Http.downloadFile({
  url: "https://upload.wikimedia.org/wikipedia/commons/6/69/Linus_Torvalds.jpeg",
  filePath: "linus.jpeg",
  fileDirectory: "DOWNLOADS",
  method: "GET",
  progress: true
});
```

### API and definitions concers
ProgressType is ` 'DOWNLOAD' | 'UPLOAD' ` and so does `HttpProgressListener` indicate generic interface but only `'DOWNLOAD'` is supported at this moment - should it be `'DOWNLOAD'` only?

### Web implementation concerns and decisions
There is no built-in (AFAIK) progress reporting mechanism in standard fetch API so there are two ways:

- Use some custom fetch library e.g axios, fetch-progress or other to offload support for chunk combining logic but at the cost of breaking change (webFetchExtra arguments may be be different depending on library)
- Write custom one - at the obvious cost of reinventing the wheel (debugging and maintaining it)

For the initial support I went with writing simple chunk combiner by using streams and it also is **opt-in** - default behaviour happens when the `progress` is set to false or is not set at all.

Not sure if the implementation should be placed in `web.ts`.
Event notifying in the initial implementation is not in any way throttled.
Content-Type of response is currently also not being added to Blob. 

It works for most cases I tried, would appreciate some testing though to make sure it works good enough.

> **Note**: The current (simple) implementation can be hard for memory since chunks are indeed stored in memory (should take at most memory equal to the downloaded file size).
It can probably be optimized to not consume that much memory, if it's required to be merged I can try to optimize it.

### Android implementation concerns and decisions
For the android support I went with notyfing listeners in `Http.java` file by using `@FunctionalInterface` lambda passed down to `HttpRequestHandler`

`ProgressEmitter` was defined in `HttpRequestHandler`, but in order to support requests and uploadFile it would need to be probably defined and passed even farther down in `CapacitorHttpUrlConnection.java` or require some kind of rewrite.

Just like it is in the web case, android implementation is also not throttled in the initial implementation.


