### PR TITLE
Bugfix/empty response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Fork from <a href="https://github.com/capacitor-community/http">capacitor-community/http</a>. For development use branch 'ergon-master'.
-
 <p align="center"><br><img src="https://user-images.githubusercontent.com/236501/85893648-1c92e880-b7a8-11ea-926d-95355b8175c7.png" width="128" height="128" /></p>
 <h3 align="center">HTTP</h3>
 <p align="center"><strong><code>@capacitor-community/http</code></strong></p>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Fork from <a href="https://github.com/capacitor-community/http">capacitor-community/http</a>. For development use branch 'ergon-master'.
+
 <p align="center"><br><img src="https://user-images.githubusercontent.com/236501/85893648-1c92e880-b7a8-11ea-926d-95355b8175c7.png" width="128" height="128" /></p>
 <h3 align="center">HTTP</h3>
 <p align="center"><strong><code>@capacitor-community/http</code></strong></p>

--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -251,7 +251,7 @@ public class HttpRequestHandler {
     private static Object parseJSON(String input) throws JSONException {
         JSONObject json = new JSONObject();
         try {
-            if ("null".equals(input.trim())) {
+            if (input.isEmpty() || "null".equals(input.trim())) {
                 return JSONObject.NULL;
             } else if ("true".equals(input.trim())) {
                 return new JSONObject().put("flag", "true");


### PR DESCRIPTION
If the response body is an empty string, a JSON exception is thrown. -> Fixed by checking for empty input and returning `JSONObject.NULL`