### PR TITLE
feat: add switch to allow overwriting downloaded file on iOS

### DIFF
--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -264,6 +264,7 @@ class HttpRequestHandler {
         let params = (call.getObject("params") ?? [:]) as! [String: Any]
         let connectTimeout = call.getDouble("connectTimeout");
         let readTimeout = call.getDouble("readTimeout");
+        let overwrite = call.getBool("overwrite") ?? false
 
         guard let urlString = call.getString("url") else { throw URLError(.badURL) }
         guard let filePath = call.getString("filePath") else { throw URLError(.badURL) }
@@ -306,10 +307,14 @@ class HttpRequestHandler {
 
                 try FilesystemUtils.createDirectoryForFile(dest, true)
 
+                if (overwrite) {
+                    try? fileManager.removeItem(at: dest)
+                }
+
                 try fileManager.moveItem(at: location, to: dest)
                 call.resolve(["path": dest.absoluteString])
             } catch let e {
-                call.reject("Unable to download file", "DOWNLOAD", e)
+                call.reject("Unable to write file at destination", "DOWNLOAD", e)
                 return
             }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -84,6 +84,12 @@ export interface HttpDownloadFileOptions extends HttpOptions {
    * If this option is used, filePath can be a relative path rather than absolute
    */
   fileDirectory?: Directory;
+  /**
+   * Optionally, the switch to enable overwriting destination file (iOS only)
+   *
+   * This does not affect Android since it overwrites by default
+   */
+  overwrite?: boolean;
 }
 
 export interface HttpUploadFileOptions extends HttpOptions {


### PR DESCRIPTION
Resolves #52 

While implementing iOS downloadFile progress I have personally stumbled on the issue and thought why not try to fix it while I'm there.

I saw your comment on the issue @thomasvidas  and you seemed opposed about making overwrite by default but the current android implementation seems to overwrite by default, do we keep the current android behaviour or should I adjust android implementation to throw error when destination file already exists too? (It kinda can be breaking change for existing users)

Also clarified error message to "Unable to write file at destination" instead of "Unable to download file" in directory creation/moving file try-catch section since it doesn't have anything to do with downloading the file.