### PR TITLE
Fix various cookies issues

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/CapacitorCookieManager.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/CapacitorCookieManager.java
@@ -20,22 +20,6 @@ public class CapacitorCookieManager extends CookieManager {
 
     private final android.webkit.CookieManager webkitCookieManager;
 
-    private String encode(String value) {
-        try {
-            return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
-        } catch (UnsupportedEncodingException ex) {
-            return "";
-        }
-    }
-
-    private String decode(String value) {
-        try {
-            return URLDecoder.decode(value, StandardCharsets.UTF_8.toString());
-        } catch (UnsupportedEncodingException ex) {
-            return "";
-        }
-    }
-
     /**
      * Create a new cookie manager for use with @capacitor-community/http with the default cookie
      * store and policy
@@ -97,7 +81,7 @@ public class CapacitorCookieManager extends CookieManager {
                 String[] singleCookie = cookieString.split(";");
                 for (String c : singleCookie) {
                     HttpCookie parsed = HttpCookie.parse(c).get(0);
-                    parsed.setValue(decode(parsed.getValue()));
+                    parsed.setValue(parsed.getValue());
                     cookieList.add(parsed);
                 }
             }
@@ -127,7 +111,7 @@ public class CapacitorCookieManager extends CookieManager {
      * @param value the value of the {@code HttpCookie} given a key
      */
     public void setCookie(String url, String key, String value) {
-        String cookieValue = key + "=" + encode(value);
+        String cookieValue = key + "=" + value;
         setCookie(url, cookieValue);
     }
 

--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -259,6 +259,18 @@ public class Http extends Plugin {
 
     @PluginMethod
     public void clearCookies(PluginCall call) {
+        String url = getServerUrl(call);
+        if (!url.isEmpty()) {
+            HttpCookie[] cookies = cookieManager.getCookies(url);
+            for (HttpCookie cookie : cookies) {
+                cookieManager.setCookie(url, cookie.getName() + "=; Expires=Wed, 31 Dec 2000 23:59:59 GMT");
+            }
+            call.resolve();
+        }
+    }
+
+    @PluginMethod
+    public void clearAllCookies(PluginCall call) {
         cookieManager.removeAllCookies();
         call.resolve();
     }

--- a/ios/Plugin/CapacitorCookieManager.swift
+++ b/ios/Plugin/CapacitorCookieManager.swift
@@ -47,4 +47,9 @@ public class CapacitorCookieManager {
         let jar = HTTPCookieStorage.shared
         jar.cookies(for: url)?.forEach({ (cookie) in jar.deleteCookie(cookie) })
     }
+    
+    public func clearAllCookies() {
+        let jar = HTTPCookieStorage.shared
+        jar.cookies?.forEach({ (cookie) in jar.deleteCookie(cookie) })
+    }
 }

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -13,6 +13,7 @@ CAP_PLUGIN(HttpPlugin, "Http",
   CAP_PLUGIN_METHOD(getCookie, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(deleteCookie, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(clearCookies, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(clearAllCookies, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(downloadFile, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(uploadFile, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -9,6 +9,7 @@ CAP_PLUGIN(HttpPlugin, "Http",
   CAP_PLUGIN_METHOD(patch, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(del, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(setCookie, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(getCookiesMap, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getCookies, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getCookie, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(deleteCookie, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -154,9 +154,13 @@ import Foundation
     @objc func clearCookies(_ call: CAPPluginCall) {
         let url = getServerUrl(call)
         if url != nil {
-            let jar = HTTPCookieStorage.shared
-            jar.cookies(for: url!)?.forEach({ (cookie) in jar.deleteCookie(cookie) })
+            cookieManager!.clearCookies(url!)
             call.resolve()
         }
+    }
+    
+    @objc func clearAllCookies(_ call: CAPPluginCall) {
+        cookieManager!.clearAllCookies()
+        call.resolve()
     }
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -104,6 +104,18 @@ import Foundation
             call.resolve()
         }
     }
+    
+    @objc func getCookiesMap(_ call: CAPPluginCall) {
+        let url = getServerUrl(call)
+        if url != nil {
+            let cookies = cookieManager!.getCookies(url!)
+            var cookiesMap: [String: String] = [:]
+            for cookie in cookies {
+                cookiesMap[cookie.name] = cookie.value
+            }
+            call.resolve(cookiesMap)
+        }
+    }
 
     @objc func getCookies(_ call: CAPPluginCall) {
         let url = getServerUrl(call)

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -16,6 +16,7 @@ export interface HttpPlugin {
   getCookies(options: HttpMultiCookiesOptions): Promise<HttpGetCookiesResult>;
   getCookiesMap(): Promise<HttpCookieMap>;
   clearCookies(options: HttpMultiCookiesOptions): Promise<void>;
+  clearAllCookies(): Promise<void>;
   deleteCookie(options: HttpSingleCookieOptions): Promise<void>;
 
   uploadFile(options: HttpUploadFileOptions): Promise<HttpUploadFileResult>;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -14,7 +14,7 @@ export interface HttpPlugin {
   setCookie(options: HttpSetCookieOptions): Promise<void>;
   getCookie(options: HttpSingleCookieOptions): Promise<HttpCookie>;
   getCookies(options: HttpMultiCookiesOptions): Promise<HttpGetCookiesResult>;
-  getCookiesMap(): Promise<HttpCookieMap>;
+  getCookiesMap(options: HttpMultiCookiesOptions): Promise<HttpCookieMap>;
   clearCookies(options: HttpMultiCookiesOptions): Promise<void>;
   clearAllCookies(): Promise<void>;
   deleteCookie(options: HttpSingleCookieOptions): Promise<void>;

--- a/src/web.ts
+++ b/src/web.ts
@@ -68,7 +68,10 @@ export class HttpWeb extends WebPlugin implements HttpPlugin {
   /**
    * Gets all HttpCookies as a Map
    */
-  public getCookiesMap = async (): Promise<HttpCookieMap> => {
+  public getCookiesMap = async (
+    // @ts-ignore
+    options: HttpMultiCookiesOptions,
+  ): Promise<HttpCookieMap> => {
     const cookies = Cookie.getCookies();
     const output: HttpCookieMap = {};
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -128,6 +128,11 @@ export class HttpWeb extends WebPlugin implements HttpPlugin {
   ): Promise<void> => Cookie.clearCookies();
 
   /**
+   * Clears out cookies by setting them to expire immediately
+   */
+  public clearAllCookies = async (): Promise<void> => Cookie.clearCookies();
+
+  /**
    * Uploads a file through a POST request
    * @param options TODO
    */


### PR DESCRIPTION
This PR fixes the following cookies issues:
- Fix `setCookie()` on android. Currently, it is not possible to set a Set-Cookie HTTP response header as part of the cookie value due to the encoding step. For instance, setting a cookie with the value `en; Max-Age=5` will be replaced to `en%3B+Max-Age%3D5` and hence Max-Age will not be taken into account. Thus, this PR removes the encoding/decoding steps on android.
- `clearCookies()` on android is implemented differently than on ios. On android all cookies are removed, on ios only those from the passed URL. This PR fixes this issue by introducing a new method `clearAllCookies()` and adjusting the respective methods on android/ios.
- Fix definition for getCookiesMap and add implementation for `getCookiesMap()` on ios.