### PR TITLE
Android: Ensure proper URL formatting without encoding, skip setParams if empty

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -127,6 +127,11 @@ public class HttpRequestHandler {
             String initialQueryBuilderStr = initialQuery == null ? "" : initialQuery;
 
             Iterator<String> keys = params.keys();
+            
+            if (!keys.hasNext()) {
+                return this;
+            }
+            
             StringBuilder urlQueryBuilder = new StringBuilder(initialQueryBuilderStr);
 
             // Build the new query string
@@ -162,7 +167,7 @@ public class HttpRequestHandler {
                 URI encodedUri = new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), urlQuery, uri.getFragment());
                 this.url = encodedUri.toURL();
             } else {
-                String unEncodedUrlString = uri.getScheme() + uri.getAuthority() + uri.getPath() + urlQuery + uri.getFragment();
+                String unEncodedUrlString = uri.getScheme() + "://" + uri.getAuthority() + uri.getPath() + ((!urlQuery.equals("")) ? "?" + urlQuery : "") + ((uri.getFragment() != null) ? uri.getFragment() : "");
                 this.url = new URL(unEncodedUrlString);
             }
 
@@ -362,6 +367,7 @@ public class HttpRequestHandler {
         Integer connectTimeout = call.getInt("connectTimeout");
         Integer readTimeout = call.getInt("readTimeout");
         Boolean disableRedirects = call.getBoolean("disableRedirects");
+        Boolean shouldEncode = call.getBoolean("shouldEncodeUrlParams", true);
         ResponseType responseType = ResponseType.parse(call.getString("responseType"));
 
         String method = httpMethod != null ? httpMethod.toUpperCase() : call.getString("method", "").toUpperCase();
@@ -373,7 +379,7 @@ public class HttpRequestHandler {
             .setUrl(url)
             .setMethod(method)
             .setHeaders(headers)
-            .setUrlParams(params)
+            .setUrlParams(params, shouldEncode)
             .setConnectTimeout(connectTimeout)
             .setReadTimeout(readTimeout)
             .setDisableRedirects(disableRedirects)


### PR DESCRIPTION
Added reading the option "shouldEncodeUrlParams" from JS and passed it on to setParams.
Fixed URL formatting in setParams when no encoding.
Added early return in setParams if params are empty, and skipped the URL formatting altogether.

This should fix #62 and #101