### PR TITLE
Fix android http upload bugs

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/FilesystemUtils.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/FilesystemUtils.java
@@ -16,7 +16,7 @@ public class FilesystemUtils {
     public static final String DIRECTORY_EXTERNAL_STORAGE = "EXTERNAL_STORAGE";
 
     public static File getFileObject(Context c, String path, String directory) {
-        if (directory == null) {
+        if (directory == null || path.startsWith("file://")) {
             Uri u = Uri.parse(path);
             if (u.getScheme() == null || u.getScheme().equals("file")) {
                 return new File(u.getPath());

--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -471,7 +471,7 @@ public class HttpRequestHandler {
      */
     public static JSObject uploadFile(PluginCall call, Context context) throws IOException, URISyntaxException, JSONException {
         String urlString = call.getString("url");
-        String method = call.getString("method").toUpperCase();
+        String method = call.getString("method", "POST").toUpperCase();
         String filePath = call.getString("filePath");
         String fileDirectory = call.getString("fileDirectory", FilesystemUtils.DIRECTORY_DOCUMENTS);
         String name = call.getString("name", "file");


### PR DESCRIPTION
- Fixes #183, where if you do not specify the `method` parameter to `Http.uploadFile` then it always returns an error, by defaulting to POST like iOS does.
- Fixes a bug where you cannot specify a `file://` URI as the `filePath` parameter on Android, which works on iOS.