### PR TITLE
Feature: Throttle listener notifications

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -21,6 +21,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -443,13 +443,19 @@ public class HttpRequestHandler {
 
         byte[] buffer = new byte[1024];
         int len;
+        long lastEmit = new Date().getTime();
 
         while ((len = connectionInputStream.read(buffer)) > 0) {
             fileOutputStream.write(buffer, 0, len);
 
             bytes += len;
-            progress.emit(bytes, maxBytes);
+
+            if (lastEmit + 1000 < new Date().getTime() || bytes == maxBytes) {
+                progress.emit(bytes, maxBytes);
+                lastEmit = new Date().getTime();
+            }
         }
+
 
         connectionInputStream.close();
         fileOutputStream.close();


### PR DESCRIPTION
Hi,
Thanks for the amazing plugin!
However i noticed while downloading larger files (~50 to 100mb) and tring to use the progress listener, that so many capacitor notifyListeners calls are created, that this slowed down the whole app as well as the download itself.
when throttling this to 1 per second everything wokrs very well.
maybe it would be a good  idea to have the throttle interval configurable and disableable?
Cheers Phil