### PR TITLE
Feat: Support multipart form data with same attribute name

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/FormUploader.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/FormUploader.java
@@ -131,9 +131,13 @@ public class FormUploader {
                 try {
                     Object value = data.get(key);
 
-                    if (!(value instanceof String)) continue;
-
-                    appendFieldToWriter(key, value.toString());
+                    if (value instanceof String) {
+                        appendFieldToWriter(key, value.toString());
+                    } else if (value instanceof String[]) {
+                        for (childValue : value) {
+                            appendFieldToWriter(key, childValue.toString());
+                        }
+                    }
                 } catch (JSONException e) {
                     e.printStackTrace();
                 }

--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -123,9 +123,6 @@ class HttpRequestHandler {
     }
 
     private static func generateMultipartForm(_ url: URL, _ name: String, _ boundary: String, _ body: [String:Any]) throws -> Data {
-        let strings: [String: String] = body.compactMapValues { any in
-            any as? String
-        }
 
         var data = Data()
 
@@ -139,10 +136,18 @@ class HttpRequestHandler {
             using: .utf8)!)
         data.append("Content-Type: \(mimeType)\r\n\r\n".data(using: .utf8)!)
         data.append(fileData)
-        strings.forEach { key, value in
-            data.append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
-            data.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".data(using: .utf8)!)
-            data.append(value.data(using: .utf8)!)
+        body.forEach { key, value in
+            if let stringArray = value as? [String] {
+                for item in stringArray {
+                    data.append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
+                    data.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".data(using: .utf8)!)
+                    data.append(item.data(using: .utf8)!)
+                }
+            } else {
+                data.append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
+                data.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".data(using: .utf8)!)
+                data.append((value as! String).data(using: .utf8)!)
+            }
         }
         data.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
 


### PR DESCRIPTION
When uploading file with `multipart/form-data`, there's ability to send the list of value, with same attribute name. 

Let's have a look on this payload, assuming we're uploading a document with some additional information, these information will be attached into `multipart/form-data`. Here's an example of the payload pass from webview to the plugin:

```js
{
    foo: 'First information',
    bar: 'Second information'
}
```

What if user want to send a list of `bar`, instead only 1 string value?

```js
{
    foo: 'First information',
    bar: ['Second information', 'Third information']
}
```

I added the ability to check the type of the value, before adding it to the form data. If it's a string, we'll go ahead as usual. If it's a string array, each item will be added to the form data, with a same name.

See more example of JS implementation at: https://developer.mozilla.org/en-US/docs/Web/API/FormData/append