### PR TITLE
fix(ios): null in body or result

### DIFF
--- a/ios/Plugin/CapacitorUrlRequest.swift
+++ b/ios/Plugin/CapacitorUrlRequest.swift
@@ -25,7 +25,9 @@ public class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
     
     private func getRequestDataAsJson(_ data: JSValue) throws -> Data? {
         // We need to check if the JSON is valid before attempting to serialize, as JSONSerialization.data will not throw an exception that can be caught, and will cause the application to crash if it fails.
-        if JSONSerialization.isValidJSONObject(data) {
+        if (data is NSNull) {
+            return "null".data(using: .utf8)
+        } else if JSONSerialization.isValidJSONObject(data) {
             return try JSONSerialization.data(withJSONObject: data)
         } else {
             throw CapacitorUrlRequest.CapacitorUrlRequestError.serializationError("[ data ] argument for request of content-type [ application/json ] must be serializable to JSON")

--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -31,11 +31,15 @@ fileprivate enum ResponseType: String {
 ///     - data: The JSON Data to parse
 /// - Returns: The parsed value or an error
 func tryParseJson(_ data: Data) -> Any {
-  do {
-    return try JSONSerialization.jsonObject(with: data, options: .mutableContainers)
-  } catch {
-    return error.localizedDescription
-  }
+    if data.elementsEqual("null".data(using: .utf8)!) {
+        return NSNull()
+    }
+    
+    do {
+        return try JSONSerialization.jsonObject(with: data, options: .mutableContainers)
+    } catch {
+        return error.localizedDescription
+    }
 }
 
 class HttpRequestHandler {


### PR DESCRIPTION
I'm having a problem with iOS if data is null.
`await Http.request({ 'POST', 'https://...', headers: { 'Content-Type': 'application/json', Accept: 'application/json' }, data: null });`
This throws an error. If result is JSON-null, then is thrown an error too.
This PR fixes both bugs.