### PR TITLE
Add fragmentsAllowed option to JSONSerialization.jsonObject

### DIFF
--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -32,7 +32,7 @@ fileprivate enum ResponseType: String {
 /// - Returns: The parsed value or an error
 func tryParseJson(_ data: Data) -> Any {
   do {
-    return try JSONSerialization.jsonObject(with: data, options: .mutableContainers)
+    return try JSONSerialization.jsonObject(with: data, options: [.mutableContainers, .allowFragments])
   } catch {
     return error.localizedDescription
   }

--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -32,7 +32,7 @@ fileprivate enum ResponseType: String {
 /// - Returns: The parsed value or an error
 func tryParseJson(_ data: Data) -> Any {
   do {
-    return try JSONSerialization.jsonObject(with: data, options: [.mutableContainers, .allowFragments])
+    return try JSONSerialization.jsonObject(with: data, options: [.mutableContainers, .fragmentsAllowed])
   } catch {
     return error.localizedDescription
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fmt": "npm run prettier -- --write",
     "prettier": "prettier \"**/*.{css,html,ts,js,java}\"",
     "prepublishOnly": "npm run build && npm run ios:build",
-    "prepare": "husky install"
+    "prepare": "husky install && npm run build"
   },
   "author": "Max Lynch <max@ionic.io>, Thomas Vidas <thomas@ionic.io>",
   "license": "MIT",


### PR DESCRIPTION
We have a request to an API that is returning a JSON string (not an object). We'd like to have this response parsed, but the option for `fragmentsAllowed` is needed in order to parse non-object JSON. This change should allow those JSON strings, numbers, booleans, etc. to be parsed in addition to objects.

**Note:** The `npm run build` added to the `prepare` script in `package.json` allows us to install the capacitor plugin from a github repository, which we're doing in the meantime. This can be removed if desired, as it's not needed when the plugin is published in an npm registry.