### PR TITLE
Download file response headers

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/HttpRequestHandler.java
@@ -463,6 +463,7 @@ public class HttpRequestHandler {
         return new JSObject() {
             {
                 put("path", file.getAbsolutePath());
+                put("headers", buildResponseHeaders((CapacitorHttpUrlConnection) connection));
             }
         };
     }

--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -296,10 +296,10 @@ class HttpRequestHandler {
                 try FilesystemUtils.createDirectoryForFile(dest, true)
 
                 try fileManager.moveItem(at: location, to: dest)
-                call.resolve(
-                    ["path": dest.absoluteString],
-                    ["headers": response.allHeaderFields]
-                )
+                call.resolve([
+                        "path": dest.absoluteString,
+                        "headers": (response as? HTTPURLResponse)?.allHeaderFields
+                    ])
             } catch let e {
                 call.reject("Unable to download file", "DOWNLOAD", e)
                 return

--- a/ios/Plugin/HttpRequestHandler.swift
+++ b/ios/Plugin/HttpRequestHandler.swift
@@ -296,7 +296,10 @@ class HttpRequestHandler {
                 try FilesystemUtils.createDirectoryForFile(dest, true)
 
                 try fileManager.moveItem(at: location, to: dest)
-                call.resolve(["path": dest.absoluteString])
+                call.resolve(
+                    ["path": dest.absoluteString],
+                    ["headers": response.allHeaderFields]
+                )
             } catch let e {
                 call.reject("Unable to download file", "DOWNLOAD", e)
                 return

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -170,6 +170,7 @@ export interface HttpGetCookiesResult {
 export interface HttpDownloadFileResult {
   path?: string;
   blob?: Blob;
+  headers?: HttpHeaders;
 }
 
 export interface HttpUploadFileResult extends HttpResponse {}


### PR DESCRIPTION
This PR updates the iOS and Android versions of DownloadFile to return http headers as requested here: https://github.com/capacitor-community/http/issues/30. I understand this repo is in maintenance mode so I understand it may not be something you're interested in updating.